### PR TITLE
Fix storybook image tagging when ran outside of release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,8 @@ on:
       - 'dev**'
       - 'staging**'
       - 'prod**'
-#  uncomment this to get automatic deploys on master branch ("branches" should be on same indent as "tags")
+    # uncomment this to get automatic deploys on master branch ("branches" 
+    # should be on same indent as "tags")
     branches:
      - master
 jobs:
@@ -23,7 +24,7 @@ jobs:
   deploy-dev:
     name: after dev Strapi deploy Next
     if: needs.conditions.outputs.dev == 'true'
-    needs: [conditions, deploy-dev-strapi]
+    needs: [conditions, deploy-dev-strapi, build-storybook]
     uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
       directory: next/
@@ -50,7 +51,7 @@ jobs:
 
   deploy-dev-next:
     name: dev Next
-    needs: conditions
+    needs: [conditions, build-storybook]
     if: needs.conditions.outputs.dev-next == 'true'
     uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
@@ -65,7 +66,7 @@ jobs:
   deploy-staging:
     name: after staging Strapi deploy Next
     if: needs.conditions.outputs.staging == 'true'
-    needs: [conditions, deploy-staging-strapi]
+    needs: [conditions, deploy-staging-strapi, build-storybook]
     uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
       directory: next/
@@ -94,7 +95,7 @@ jobs:
 
   deploy-staging-next:
     name: staging Next
-    needs: conditions
+    needs: [conditions, build-storybook]
     if: needs.conditions.outputs.staging-next == 'true'
     uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
@@ -110,7 +111,7 @@ jobs:
   deploy-prod:
     name: after prod Strapi deploy Next
     if: needs.conditions.outputs.prod == 'true'
-    needs: [conditions, deploy-prod-strapi]
+    needs: [conditions, deploy-prod-strapi, build-storybook]
     uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
       directory: next/
@@ -138,7 +139,7 @@ jobs:
 
   deploy-prod-next:
     name: prod Next
-    needs: conditions
+    needs: [conditions, build-storybook]
     if: needs.conditions.outputs.prod-next == 'true'
     uses: bratislava/github-actions/.github/workflows/deploy-with-bratiska-cli-inhouse.yml@stable
     with:
@@ -163,7 +164,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ vars.HARBOR_REGISTRY }}/${{ vars.HARBOR_NAMESPACE }}/olo-next-storybook
-          tags: ${{ github.ref_name }}
+          tags: ${{ github.sha }}
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2
       - name: Log into registry

--- a/next/kubernetes/base/deployment.yml
+++ b/next/kubernetes/base/deployment.yml
@@ -43,7 +43,7 @@ spec:
             periodSeconds: 20
             successThreshold: 1
             failureThreshold: 3
-        - image: ${IMAGE}-storybook:${GIT_TAG}
+        - image: ${IMAGE}-storybook:${GITHUB_SHA}
           name: storybook
           imagePullPolicy: IfNotPresent
           ports:


### PR DESCRIPTION
* Added new steps that "build" a image. When running from tag use that git tag or else use short commit SHA
* Puts `"build storybook"` as a condition for next deployment