### PR TITLE
Remove storageClass specification and set modest DB sizes

### DIFF
--- a/strapi/kubernetes/base/stateful-set.yml
+++ b/strapi/kubernetes/base/stateful-set.yml
@@ -43,7 +43,6 @@ spec:
           service: database
       spec:
         accessModes: ['ReadWriteOnce']
-        storageClassName: 'vsan-default-storage-policy'
         resources:
           requests:
-            storage: 10Gi
+            storage: ${DB_SIZE}

--- a/strapi/kubernetes/envs/Dev/config.json
+++ b/strapi/kubernetes/envs/Dev/config.json
@@ -7,6 +7,7 @@
     "DB_CPU_REQUESTS": "10m",
     "DB_MEMORY_REQUESTS": "128Mi",
     "DB_CPU_LIMITS": "1",
-    "DB_MEMORY_LIMITS": "1Gi"
+    "DB_MEMORY_LIMITS": "1Gi",
+    "DB_SIZE": "2Gi"
   }
 }

--- a/strapi/kubernetes/envs/Prod/config.json
+++ b/strapi/kubernetes/envs/Prod/config.json
@@ -7,6 +7,7 @@
     "DB_CPU_REQUESTS": "100m",
     "DB_MEMORY_REQUESTS": "128Mi",
     "DB_CPU_LIMITS": "2",
-    "DB_MEMORY_LIMITS": "2Gi"
+    "DB_MEMORY_LIMITS": "2Gi",
+    "DB_SIZE": "10Gi"
   }
 }

--- a/strapi/kubernetes/envs/Staging/config.json
+++ b/strapi/kubernetes/envs/Staging/config.json
@@ -7,6 +7,7 @@
     "DB_CPU_REQUESTS": "10m",
     "DB_MEMORY_REQUESTS": "128Mi",
     "DB_CPU_LIMITS": "1",
-    "DB_MEMORY_LIMITS": "1Gi"
+    "DB_MEMORY_LIMITS": "1Gi",
+    "DB_SIZE": "2Gi"
   }
 }


### PR DESCRIPTION
* Remove explicit declaration of `storageClass` as for this DB it is not necessary. Rather let cluster decide with default `storageClass`
* Push DB size to variable inside `config.json` and set defaults to more modest sizes for DEV and STAGING clusters