### PR TITLE
#186 Silence A11Y warnings

### DIFF
--- a/next/src/components/common/NavBar/NavMenu/NavMenuContent.tsx
+++ b/next/src/components/common/NavBar/NavMenu/NavMenuContent.tsx
@@ -41,12 +41,13 @@ const NavMenuContent = ({ sections, seeAllLinkProps, className }: NavMenuContent
           })}
         </ul>
         {seeAllLinkProps?.children ? (
+          // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
           <div
             className="flex w-full items-start justify-start border-t border-border-default py-6"
             // Together with onCLick in Viewport, it closes the menu on click outside of container area
             onClick={(event) => event.stopPropagation()}
           >
-            <NavMenuLink {...seeAllLinkProps} />
+            <NavMenuLink {...seeAllLinkProps}>{seeAllLinkProps.children}</NavMenuLink>
           </div>
         ) : null}
       </div>

--- a/next/src/components/common/NavBar/NavMenu/NavMenuSection.tsx
+++ b/next/src/components/common/NavBar/NavMenu/NavMenuSection.tsx
@@ -50,7 +50,9 @@ const NavMenuSection = ({ section, className }: NavMenuSectionProps) => {
               />
             </div>
           ) : (
-            <NavMenuLink key={link?.id} {...linkProps} />
+            <NavMenuLink key={link?.id} {...linkProps}>
+              {linkProps.children}
+            </NavMenuLink>
           )
         })}
       </ul>


### PR DESCRIPTION
- Silence A11Y-related TypeScript warnings regarding usage of click handlers on non-interactive elements `<div/>`