### PR TITLE
#186 Create a placeholder for Workshop dates

### DIFF
--- a/next/src/utils/getLatestWorkshopDateAsISOString.ts
+++ b/next/src/utils/getLatestWorkshopDateAsISOString.ts
@@ -3,7 +3,7 @@ import { WorkshopSlugEntityFragment } from '@/src/services/graphql/api'
 export const getLatestWorkshopDateAsISOString = (workshop: WorkshopSlugEntityFragment) => {
   if (!workshop.attributes?.dates) return null
   const unixTimestamp = Math.min(
-    ...workshop.attributes.dates.map((date) => new Date(date?.value).getTime()),
+    ...workshop.attributes.dates.map((date) => new Date(date?.datetime).getTime()),
   )
 
   return new Date(unixTimestamp).toISOString()

--- a/next/src/utils/useMostRecentWorkshopDate.ts
+++ b/next/src/utils/useMostRecentWorkshopDate.ts
@@ -1,7 +1,6 @@
 import { useTranslation } from 'next-i18next'
 
 import { WorkshopSlugEntityFragment } from '@/src/services/graphql/api'
-import { getLatestWorkshopDateAsISOString } from '@/src/utils/getLatestWorkshopDateAsISOString'
 
 export const useMostRecentWorkshopDate = () => {
   const { t } = useTranslation()
@@ -11,11 +10,13 @@ export const useMostRecentWorkshopDate = () => {
     if (!workshop?.attributes || !dates || dates.length === 0)
       return { mostRecentDateMessage: null }
 
-    const mostRecentDate = dates.find(
-      (date) => date?.value === getLatestWorkshopDateAsISOString(workshop),
-    )
+    // TODO: Implement a new function to handle the parsing and formatting of dates
+    /*    const mostRecentDate = dates.find(
+          (date) => date?.datetime === getLatestWorkshopDateAsISOString(workshop),
+        ) */
+
     const mostRecentDateMessage = t('navBar.workshopCard.messageMostRecentDate', {
-      mostRecentDate: mostRecentDate?.label,
+      mostRecentDate: '21. september 2024 o 9:00',
     })
 
     return { mostRecentDateMessage }


### PR DESCRIPTION
- Adjust `getLatestWorkshopDateAsISOString` to comply with the updated Strapi schema
- Temporarily display a placeholder string instead of the latest workshop date string