### PR TITLE
#491 Finish navigation middleware rewrite

### DIFF
--- a/next/.env.bratiska-cli-build.dev
+++ b/next/.env.bratiska-cli-build.dev
@@ -1,5 +1,6 @@
 NEXT_PUBLIC_DEPLOYMENT=dev
 NEXT_PUBLIC_STRAPI_URL=https://olo-strapi.dev.bratislava.sk
+NEXT_PUBLIC_NEXT_HOST=olo-next.dev.bratislava.sk
 
 NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=pk.eyJ1IjoiYnJhdGlzbGF2YTAxIiwiYSI6ImNreWp4d3RmbDJxdHcyb24wcTRzODV1Z2oifQ.ted1x1pbp8w3jZG0MygBUw
 NEXT_PUBLIC_MAPBOX_LIGHT_STYLE_ID=mapbox://styles/bratislava01/ckzrbqd6300ps14p8gpyoq3wr

--- a/next/.env.bratiska-cli-build.prod
+++ b/next/.env.bratiska-cli-build.prod
@@ -1,6 +1,7 @@
 # Rename to .env.production.local when doing production deployment
 NEXT_PUBLIC_DEPLOYMENT=prod
 NEXT_PUBLIC_STRAPI_URL=https://olo-strapi.bratislava.sk
+NEXT_PUBLIC_NEXT_HOST=olo-next.prod.bratislava.sk
 
 NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=pk.eyJ1IjoiYnJhdGlzbGF2YTAxIiwiYSI6ImNreWp4d3RmbDJxdHcyb24wcTRzODV1Z2oifQ.ted1x1pbp8w3jZG0MygBUw
 NEXT_PUBLIC_MAPBOX_LIGHT_STYLE_ID=mapbox://styles/bratislava01/ckzrbqd6300ps14p8gpyoq3wr

--- a/next/.env.bratiska-cli-build.staging
+++ b/next/.env.bratiska-cli-build.staging
@@ -1,5 +1,6 @@
 NEXT_PUBLIC_DEPLOYMENT=staging
 NEXT_PUBLIC_STRAPI_URL=https://olo-strapi.staging.bratislava.sk
+NEXT_PUBLIC_NEXT_HOST=olo-next.staging.bratislava.sk
 
 NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=pk.eyJ1IjoiYnJhdGlzbGF2YTAxIiwiYSI6ImNreWp4d3RmbDJxdHcyb24wcTRzODV1Z2oifQ.ted1x1pbp8w3jZG0MygBUw
 NEXT_PUBLIC_MAPBOX_LIGHT_STYLE_ID=mapbox://styles/bratislava01/ckzrbqd6300ps14p8gpyoq3wr

--- a/next/src/components/placeholder/usePlaceholderMenuData.ts
+++ b/next/src/components/placeholder/usePlaceholderMenuData.ts
@@ -33,13 +33,6 @@ export const usePlaceholderMenuData = () => {
               attributes: {
                 title: 'Stanovište zberných nádob',
                 slug: 'stanoviste-zbernych-nadob',
-                parentPage: {
-                  data: {
-                    attributes: {
-                      slug: 'odpad',
-                    },
-                  },
-                },
               },
             },
           },
@@ -60,13 +53,6 @@ export const usePlaceholderMenuData = () => {
               attributes: {
                 title: 'Ako triediť odpad?',
                 slug: 'ako-triedit-odpad',
-                parentPage: {
-                  data: {
-                    attributes: {
-                      slug: 'odpad',
-                    },
-                  },
-                },
               },
             },
           },
@@ -126,13 +112,6 @@ export const usePlaceholderMenuData = () => {
               attributes: {
                 title: 'Zistite si váš odvozový deň',
                 slug: 'zistite-si-vas-odvozovy-den',
-                parentPage: {
-                  data: {
-                    attributes: {
-                      slug: 'odpad',
-                    },
-                  },
-                },
               },
             },
           },
@@ -153,13 +132,6 @@ export const usePlaceholderMenuData = () => {
               attributes: {
                 title: 'Neodviezli mi odpad',
                 slug: 'neodviezli-mi-odpad',
-                parentPage: {
-                  data: {
-                    attributes: {
-                      slug: 'odpad',
-                    },
-                  },
-                },
               },
             },
           },
@@ -219,13 +191,6 @@ export const usePlaceholderMenuData = () => {
               attributes: {
                 title: 'Zistite si váš odvozový deň',
                 slug: 'zistite-si-vas-odvozovy-den',
-                parentPage: {
-                  data: {
-                    attributes: {
-                      slug: 'odpad',
-                    },
-                  },
-                },
               },
             },
           },
@@ -246,13 +211,6 @@ export const usePlaceholderMenuData = () => {
               attributes: {
                 title: 'Neodviezli mi odpad',
                 slug: 'neodviezli-mi-odpad',
-                parentPage: {
-                  data: {
-                    attributes: {
-                      slug: 'odpad',
-                    },
-                  },
-                },
               },
             },
           },

--- a/next/src/components/sections/TableSection.tsx
+++ b/next/src/components/sections/TableSection.tsx
@@ -30,8 +30,9 @@ const TableSection = ({ section }: Props) => {
               <table className="divide-y divide-border-default">
                 <thead className="bg-background-secondary">
                   <tr className="divide-x divide-border-default">
-                    {['Column 1', 'Column 2', 'Column 3'].map((column) => (
-                      <th scope="col" className="px-6 py-4 text-left">
+                    {['Column 1', 'Column 2', 'Column 3'].map((column, colIndex) => (
+                      // eslint-disable-next-line react/no-array-index-key
+                      <th key={colIndex} scope="col" className="px-6 py-4 text-left">
                         <Typography variant="p-default-bold">{column}</Typography>
                       </th>
                     ))}
@@ -40,12 +41,16 @@ const TableSection = ({ section }: Props) => {
                 <tbody className="divide-y divide-border-default">
                   {
                     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                    Array.from({ length: 4 }).map((row) => (
-                      <tr className="divide-x divide-border-default">
+                    Array.from({ length: 4 }).map((row, rowIndex) => (
+                      // eslint-disable-next-line react/no-array-index-key
+                      <tr key={rowIndex} className="divide-x divide-border-default">
                         {
                           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                          Array.from({ length: 3 }).map((cell) => (
-                            <td className="whitespace-nowrap px-6 py-4">...</td>
+                          Array.from({ length: 3 }).map((cell, colIndex) => (
+                            // eslint-disable-next-line react/no-array-index-key
+                            <td key={colIndex} className="whitespace-nowrap px-6 py-4">
+                              ...
+                            </td>
                           ))
                         }
                       </tr>

--- a/next/src/environment.ts
+++ b/next/src/environment.ts
@@ -16,4 +16,5 @@ export const environment = {
   nodeEnv: assertEnv('NODE_ENV', process.env.NODE_ENV),
   deployment: assertEnv('NEXT_PUBLIC_DEPLOYMENT', process.env.NEXT_PUBLIC_DEPLOYMENT),
   strapiUrl: assertEnv('NEXT_PUBLIC_STRAPI_URL', process.env.NEXT_PUBLIC_STRAPI_URL),
+  nextHost: assertEnv('NEXT_PUBLIC_NEXT_HOST', process.env.NEXT_PUBLIC_NEXT_HOST),
 }

--- a/next/src/middleware.ts
+++ b/next/src/middleware.ts
@@ -1,4 +1,5 @@
 import { getNavigationMiddleware } from '@/src/services/navigation/getNavigationMiddleware'
+import { navigationConfig } from '@/src/services/navigation/navigationConfig'
 
 /* Docs: https://nextjs.org/docs/pages/building-your-application/routing/middleware#matcher */
 export const config = {
@@ -14,6 +15,4 @@ export const config = {
   ],
 }
 
-export const middleware = getNavigationMiddleware({
-  cacheTtl: 10_000,
-})
+export const middleware = getNavigationMiddleware(navigationConfig)

--- a/next/src/pages/[...path].tsx
+++ b/next/src/pages/[...path].tsx
@@ -128,7 +128,14 @@ const Page = ({ entity: page, general, navigation, dehydratedState }: PageProps)
     }
   }, [scrollId])
 
-  const breadcrumbs = useMemo(() => getPageBreadcrumbs(page), [page])
+  const breadcrumbs = useMemo(
+    () =>
+      getPageBreadcrumbs(
+        navigation.pagePathsMap[page.attributes?.slug ?? '']?.path ?? '',
+        navigation.pagePathsMap,
+      ),
+    [navigation.pagePathsMap, page],
+  )
 
   if (!page.attributes) {
     return null

--- a/next/src/pages/api/navigation.ts
+++ b/next/src/pages/api/navigation.ts
@@ -10,7 +10,10 @@ const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
   const { pagePathsMap } = parseTopLevelPages(topLevelPages?.data ?? [])
   const { contentTypePathPrefixesMap } = parseContentTypePathPrefixes(navigation, pagePathsMap)
 
-  return res.json({ contentTypePathPrefixesMap })
+  return res.json({
+    contentTypePathPrefixesMap,
+    pagePathsMap,
+  })
 }
 
 export default handler

--- a/next/src/pages/api/navigation.ts
+++ b/next/src/pages/api/navigation.ts
@@ -5,7 +5,7 @@ import { parseContentTypePathPrefixes } from '@/src/services/navigation/parseCon
 import { parseTopLevelPages } from '@/src/services/navigation/parseTopLevelPages'
 
 const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
-  const { navigation, topLevelPages } = await client.General({ locale: 'sk' }) // TODO locale
+  const { navigation, topLevelPages } = await client.Navigation({ locale: 'sk' }) // TODO locale
 
   const { pagePathsMap } = parseTopLevelPages(topLevelPages?.data ?? [])
   const { contentTypePathPrefixesMap } = parseContentTypePathPrefixes(navigation, pagePathsMap)

--- a/next/src/pages/api/navigation.ts
+++ b/next/src/pages/api/navigation.ts
@@ -1,19 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 
-import { client } from '@/src/services/graphql'
-import { parseContentTypePathPrefixes } from '@/src/services/navigation/parseContentTypePathPrefixes'
-import { parseTopLevelPages } from '@/src/services/navigation/parseTopLevelPages'
+import { fetchNonCachedNavigation } from '@/src/services/navigation/fetchNonCachedNavigation'
 
 const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
-  const { navigation, topLevelPages } = await client.Navigation({ locale: 'sk' }) // TODO locale
+  const navigation = await fetchNonCachedNavigation()
 
-  const { pagePathsMap } = parseTopLevelPages(topLevelPages?.data ?? [])
-  const { contentTypePathPrefixesMap } = parseContentTypePathPrefixes(navigation, pagePathsMap)
-
-  return res.json({
-    contentTypePathPrefixesMap,
-    pagePathsMap,
-  })
+  return res.json(navigation)
 }
 
 export default handler

--- a/next/src/pages/articles/[slug].tsx
+++ b/next/src/pages/articles/[slug].tsx
@@ -3,11 +3,14 @@ import Head from 'next/head'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import * as React from 'react'
+import { useMemo } from 'react'
 
+import Breadcrumbs from '@/src/components/common/Breadcrumbs/Breadcrumbs'
 import Gallery from '@/src/components/common/Gallery/Gallery'
 import ShareBlock from '@/src/components/common/ShareBlock/ShareBlock'
 import Markdown from '@/src/components/formatting/Markdown'
 import PageLayout from '@/src/components/layout/PageLayout'
+import SectionContainer from '@/src/components/layout/Section/SectionContainer'
 import ArticlePageHeader from '@/src/components/sections/headers/ArticlePageHeader'
 import { GeneralContextProvider } from '@/src/providers/GeneralContextProvider'
 import { client } from '@/src/services/graphql'
@@ -15,6 +18,7 @@ import { ArticleEntityFragment, GeneralQuery } from '@/src/services/graphql/api'
 import { fetchNavigation } from '@/src/services/navigation/fetchNavigation'
 import { navigationConfig } from '@/src/services/navigation/navigationConfig'
 import { NavigationObject } from '@/src/services/navigation/typesNavigation'
+import { getPageBreadcrumbs } from '@/src/utils/getPageBreadcrumbs'
 import { isDefined } from '@/src/utils/isDefined'
 
 type PageProps = {
@@ -86,6 +90,16 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
 const Page = ({ entity, general, navigation }: PageProps) => {
   const { t } = useTranslation()
 
+  // TODO consider extracting this to a hook for all detail pages
+  const parentPagePath = navigation.contentTypePathPrefixesMap.article ?? ''
+  const breadcrumbs = useMemo(
+    () => [
+      ...getPageBreadcrumbs(parentPagePath, navigation.pagePathsMap),
+      { title: entity.attributes?.title ?? '', path: null },
+    ],
+    [entity.attributes?.title, navigation.pagePathsMap, parentPagePath],
+  )
+
   if (!entity.attributes) {
     return null
   }
@@ -104,6 +118,10 @@ const Page = ({ entity, general, navigation }: PageProps) => {
       </Head>
 
       <PageLayout>
+        <SectionContainer background="secondary">
+          <Breadcrumbs breadcrumbs={breadcrumbs} />
+        </SectionContainer>
+
         <ArticlePageHeader article={entity} />
 
         {/* TODO separate outer div(s) to Article Section with narrow layout */}

--- a/next/src/pages/articles/[slug].tsx
+++ b/next/src/pages/articles/[slug].tsx
@@ -12,10 +12,14 @@ import ArticlePageHeader from '@/src/components/sections/headers/ArticlePageHead
 import { GeneralContextProvider } from '@/src/providers/GeneralContextProvider'
 import { client } from '@/src/services/graphql'
 import { ArticleEntityFragment, GeneralQuery } from '@/src/services/graphql/api'
+import { fetchNavigation } from '@/src/services/navigation/fetchNavigation'
+import { navigationConfig } from '@/src/services/navigation/navigationConfig'
+import { NavigationObject } from '@/src/services/navigation/typesNavigation'
 import { isDefined } from '@/src/utils/isDefined'
 
 type PageProps = {
   general: GeneralQuery
+  navigation: NavigationObject
   entity: ArticleEntityFragment
 }
 
@@ -56,9 +60,10 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
     return { notFound: true }
   }
 
-  const [{ articles: entities }, general, translations] = await Promise.all([
+  const [{ articles: entities }, general, navigation, translations] = await Promise.all([
     client.ArticleBySlug({ slug, locale }),
     client.General({ locale }),
+    fetchNavigation(navigationConfig),
     serverSideTranslations(locale),
   ])
 
@@ -71,13 +76,14 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
     props: {
       entity,
       general,
+      navigation,
       ...translations,
     },
     revalidate: 1, // TODO change to 10
   }
 }
 
-const Page = ({ entity, general }: PageProps) => {
+const Page = ({ entity, general, navigation }: PageProps) => {
   const { t } = useTranslation()
 
   if (!entity.attributes) {
@@ -90,7 +96,7 @@ const Page = ({ entity, general }: PageProps) => {
   const filteredGalleryImages = gallery?.data.filter(isDefined) ?? []
 
   return (
-    <GeneralContextProvider general={general}>
+    <GeneralContextProvider general={general} navigation={navigation}>
       {/* TODO common Head/Seo component */}
       <Head>
         <title>{title}</title>

--- a/next/src/pages/documents/[slug].tsx
+++ b/next/src/pages/documents/[slug].tsx
@@ -73,13 +73,13 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
 
 const Page = ({ entity, general, navigation }: PageProps) => {
   // TODO consider extracting this to a hook for all detail pages
-  const documentsParentPage = general.navigation?.data?.attributes?.documentsParentPage?.data
+  const parentPagePath = navigation.contentTypePathPrefixesMap.document ?? ''
   const breadcrumbs = useMemo(
     () => [
-      ...getPageBreadcrumbs(documentsParentPage),
+      ...getPageBreadcrumbs(parentPagePath, navigation.pagePathsMap),
       { title: entity.attributes?.title ?? '', path: null },
     ],
-    [documentsParentPage, entity.attributes?.title],
+    [entity.attributes?.title, navigation.pagePathsMap, parentPagePath],
   )
 
   if (!entity.attributes) {

--- a/next/src/pages/faq-categories/[slug].tsx
+++ b/next/src/pages/faq-categories/[slug].tsx
@@ -74,14 +74,13 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
 
 const Page = ({ entity, general, navigation }: PageProps) => {
   // TODO consider extracting this to a hook for all detail pages
-  const faqCategoriesParentPage =
-    general.navigation?.data?.attributes?.faqCategoriesParentPage?.data
-  const breadcrumbs = React.useMemo(
+  const parentPagePath = navigation.contentTypePathPrefixesMap.faqCategory ?? ''
+  const breadcrumbs = useMemo(
     () => [
-      ...getPageBreadcrumbs(faqCategoriesParentPage),
+      ...getPageBreadcrumbs(parentPagePath, navigation.pagePathsMap),
       { title: entity.attributes?.title ?? '', path: null },
     ],
-    [faqCategoriesParentPage, entity.attributes?.title],
+    [entity.attributes?.title, navigation.pagePathsMap, parentPagePath],
   )
 
   if (!entity.attributes) {

--- a/next/src/pages/form.tsx
+++ b/next/src/pages/form.tsx
@@ -7,28 +7,34 @@ import PageLayout from '@/src/components/layout/PageLayout'
 import { GeneralContextProvider } from '@/src/providers/GeneralContextProvider'
 import { client } from '@/src/services/graphql'
 import { GeneralQuery } from '@/src/services/graphql/api'
+import { fetchNavigation } from '@/src/services/navigation/fetchNavigation'
+import { navigationConfig } from '@/src/services/navigation/navigationConfig'
+import { NavigationObject } from '@/src/services/navigation/typesNavigation'
 
 type PageProps = {
   general: GeneralQuery
+  navigation: NavigationObject
 }
 
 export const getServerSideProps: GetServerSideProps<PageProps> = async ({ locale = 'sk' }) => {
-  const [general, translations] = await Promise.all([
+  const [general, navigation, translations] = await Promise.all([
     client.General({ locale }),
+    fetchNavigation(navigationConfig),
     serverSideTranslations(locale),
   ])
 
   return {
     props: {
       general,
+      navigation,
       ...translations,
     },
   }
 }
 
-const Page = ({ general }: PageProps) => {
+const Page = ({ general, navigation }: PageProps) => {
   return (
-    <GeneralContextProvider general={general}>
+    <GeneralContextProvider general={general} navigation={navigation}>
       <PageLayout>
         <IframeResizer
           license="GPLv3"

--- a/next/src/pages/index.tsx
+++ b/next/src/pages/index.tsx
@@ -11,10 +11,14 @@ import ServicesHomepageSection from '@/src/components/sections/hompage/ServicesH
 import { GeneralContextProvider } from '@/src/providers/GeneralContextProvider'
 import { client } from '@/src/services/graphql'
 import { GeneralQuery, HomepageEntityFragment } from '@/src/services/graphql/api'
+import { fetchNavigation } from '@/src/services/navigation/fetchNavigation'
+import { navigationConfig } from '@/src/services/navigation/navigationConfig'
+import { NavigationObject } from '@/src/services/navigation/typesNavigation'
 
 type PageProps = {
   homepage: HomepageEntityFragment
   general: GeneralQuery
+  navigation: NavigationObject
 }
 
 export const getStaticProps: GetStaticProps<PageProps> = async ({ locale }) => {
@@ -25,9 +29,10 @@ export const getStaticProps: GetStaticProps<PageProps> = async ({ locale }) => {
     return { notFound: true }
   }
 
-  const [{ homepage }, general, translations] = await Promise.all([
+  const [{ homepage }, general, navigation, translations] = await Promise.all([
     client.Homepage({ locale }),
     client.General({ locale }),
+    fetchNavigation(navigationConfig),
     serverSideTranslations(locale),
   ])
 
@@ -40,6 +45,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async ({ locale }) => {
     props: {
       homepage: page,
       general,
+      navigation,
       ...translations,
     },
     revalidate: 1, // TODO change to 10
@@ -47,7 +53,7 @@ export const getStaticProps: GetStaticProps<PageProps> = async ({ locale }) => {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const Homepage = ({ homepage, general }: PageProps) => {
+const Homepage = ({ homepage, general, navigation }: PageProps) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { t } = useTranslation()
   // const title = useTitle()
@@ -57,38 +63,14 @@ const Homepage = ({ homepage, general }: PageProps) => {
    * https://github.com/bratislava/bratislava.sk/blob/master/next/pages/index.tsx
    */
   return (
-    <GeneralContextProvider general={general}>
+    <GeneralContextProvider general={general} navigation={navigation}>
       <PageLayout>
         <HeroHomepageSection section={homepage.attributes?.heroSection} />
         <ArticlesHomepageSection section={homepage.attributes?.articlesSection} />
         <KoloHomepageSection section={homepage.attributes?.koloSection} />
         <ServicesHomepageSection section={homepage.attributes?.servicesSection} />
-        {/* <HomePageContentPlaceholder /> */}
       </PageLayout>
     </GeneralContextProvider>
-
-    // TODO replace placeholder with proper component based on homepage props. Example below (needs to be a proper component, however):
-
-    //   <Section>
-    //   {homepage.attributes?.slides?.map((slide, index) => (
-    //     <div
-    //       // eslint-disable-next-line react/no-array-index-key
-    //       key={index}
-    //       className="rounded-lg p-6"
-    //       style={{ backgroundColor: slide?.backgroundColor ?? '' }}
-    //     >
-    //       <Typography variant="h1" as="p">
-    //         {slide?.title}
-    //       </Typography>
-    //       <Typography>{slide?.text}</Typography>
-    //       <Typography>{slide?.backgroundColor}</Typography>
-
-    //       {slide?.media.data?.attributes ? (
-    //         <Image src={slide.media.data.attributes.url} alt="" />
-    //       ) : null}
-    //     </div>
-    //   ))}
-    // </Section>
   )
 }
 

--- a/next/src/pages/services/[slug].tsx
+++ b/next/src/pages/services/[slug].tsx
@@ -12,10 +12,14 @@ import ServicePageHeader from '@/src/components/sections/headers/ServicePageHead
 import { GeneralContextProvider } from '@/src/providers/GeneralContextProvider'
 import { client } from '@/src/services/graphql'
 import { GeneralQuery, ServiceEntityFragment } from '@/src/services/graphql/api'
+import { fetchNavigation } from '@/src/services/navigation/fetchNavigation'
+import { navigationConfig } from '@/src/services/navigation/navigationConfig'
+import { NavigationObject } from '@/src/services/navigation/typesNavigation'
 import { getPageBreadcrumbs } from '@/src/utils/getPageBreadcrumbs'
 
 type PageProps = {
   general: GeneralQuery
+  navigation: NavigationObject
   entity: ServiceEntityFragment
 }
 
@@ -56,9 +60,10 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
     return { notFound: true }
   }
 
-  const [{ services: entities }, general, translations] = await Promise.all([
+  const [{ services: entities }, general, navigation, translations] = await Promise.all([
     client.ServiceBySlug({ slug, locale }),
     client.General({ locale }),
+    fetchNavigation(navigationConfig),
     serverSideTranslations(locale),
   ])
 
@@ -71,13 +76,14 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
     props: {
       entity,
       general,
+      navigation,
       ...translations,
     },
     revalidate: 1, // TODO change to 10
   }
 }
 
-const Page = ({ entity, general }: PageProps) => {
+const Page = ({ entity, general, navigation }: PageProps) => {
   // TODO consider extracting this to a hook for all detail pages
   const servicesParentPage = general.navigation?.data?.attributes?.servicesParentPage?.data
   const breadcrumbs = useMemo(
@@ -87,6 +93,7 @@ const Page = ({ entity, general }: PageProps) => {
     ],
     [servicesParentPage, entity.attributes?.title],
   )
+
   if (!entity.attributes) {
     return null
   }
@@ -94,7 +101,7 @@ const Page = ({ entity, general }: PageProps) => {
   const { title, serviceCategories } = entity.attributes
 
   return (
-    <GeneralContextProvider general={general}>
+    <GeneralContextProvider general={general} navigation={navigation}>
       {/* TODO common Head/Seo component */}
       <Head>
         <title>{title}</title>

--- a/next/src/pages/services/[slug].tsx
+++ b/next/src/pages/services/[slug].tsx
@@ -85,13 +85,13 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
 
 const Page = ({ entity, general, navigation }: PageProps) => {
   // TODO consider extracting this to a hook for all detail pages
-  const servicesParentPage = general.navigation?.data?.attributes?.servicesParentPage?.data
+  const parentPagePath = navigation.contentTypePathPrefixesMap.service ?? ''
   const breadcrumbs = useMemo(
     () => [
-      ...getPageBreadcrumbs(servicesParentPage),
+      ...getPageBreadcrumbs(parentPagePath, navigation.pagePathsMap),
       { title: entity.attributes?.title ?? '', path: null },
     ],
-    [servicesParentPage, entity.attributes?.title],
+    [entity.attributes?.title, navigation.pagePathsMap, parentPagePath],
   )
 
   if (!entity.attributes) {

--- a/next/src/pages/workshops/[slug].tsx
+++ b/next/src/pages/workshops/[slug].tsx
@@ -86,13 +86,15 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
 
 const Page = ({ entity, general, navigation }: PageProps) => {
   // TODO consider extracting this to a hook for all detail pages
-  const workshopsParentPage = general.navigation?.data?.attributes?.workshopsParentPage?.data
+  const parentPagePath = navigation.contentTypePathPrefixesMap.workshop ?? ''
   const breadcrumbs = useMemo(
-    () => [
-      ...getPageBreadcrumbs(workshopsParentPage),
-      { title: entity.attributes?.title ?? '', path: null },
-    ],
-    [workshopsParentPage, entity.attributes?.title],
+    () =>
+      [
+        ...getPageBreadcrumbs(parentPagePath, navigation.pagePathsMap),
+        { title: entity.attributes?.title ?? '', path: null },
+        // eslint-disable-next-line unicorn/no-array-callback-reference
+      ].filter(isDefined),
+    [entity.attributes?.title, navigation.pagePathsMap, parentPagePath],
   )
 
   if (!entity.attributes) {

--- a/next/src/pages/workshops/[slug].tsx
+++ b/next/src/pages/workshops/[slug].tsx
@@ -12,11 +12,15 @@ import HeaderTitleText from '@/src/components/sections/headers/HeaderTitleText'
 import { GeneralContextProvider } from '@/src/providers/GeneralContextProvider'
 import { client } from '@/src/services/graphql'
 import { GeneralQuery, WorkshopEntityFragment } from '@/src/services/graphql/api'
+import { fetchNavigation } from '@/src/services/navigation/fetchNavigation'
+import { navigationConfig } from '@/src/services/navigation/navigationConfig'
+import { NavigationObject } from '@/src/services/navigation/typesNavigation'
 import { getPageBreadcrumbs } from '@/src/utils/getPageBreadcrumbs'
 import { isDefined } from '@/src/utils/isDefined'
 
 type PageProps = {
   general: GeneralQuery
+  navigation: NavigationObject
   entity: WorkshopEntityFragment
 }
 
@@ -57,9 +61,10 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
     return { notFound: true }
   }
 
-  const [{ workshops: entities }, general, translations] = await Promise.all([
+  const [{ workshops: entities }, general, navigation, translations] = await Promise.all([
     client.WorkshopBySlug({ slug }),
     client.General({ locale }),
+    fetchNavigation(navigationConfig),
     serverSideTranslations(locale),
   ])
 
@@ -72,13 +77,14 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
     props: {
       entity,
       general,
+      navigation,
       ...translations,
     },
     revalidate: 1, // TODO change to 10
   }
 }
 
-const Page = ({ entity, general }: PageProps) => {
+const Page = ({ entity, general, navigation }: PageProps) => {
   // TODO consider extracting this to a hook for all detail pages
   const workshopsParentPage = general.navigation?.data?.attributes?.workshopsParentPage?.data
   const breadcrumbs = useMemo(
@@ -96,7 +102,7 @@ const Page = ({ entity, general }: PageProps) => {
   const { title, sections } = entity.attributes
 
   return (
-    <GeneralContextProvider general={general}>
+    <GeneralContextProvider general={general} navigation={navigation}>
       {/* TODO common Head/Seo component */}
       <Head>
         <title>{title}</title>

--- a/next/src/providers/GeneralContextProvider.tsx
+++ b/next/src/providers/GeneralContextProvider.tsx
@@ -1,38 +1,32 @@
-import { createContext, ReactNode, useContext, useMemo } from 'react'
+import { createContext, ReactNode, useContext } from 'react'
 
 import { GeneralQuery } from '@/src/services/graphql/api'
-import {
-  ContentTypePathPrefixesMap,
-  parseContentTypePathPrefixes,
-} from '@/src/services/navigation/parseContentTypePathPrefixes'
-import { PagePathsMap, parseTopLevelPages } from '@/src/services/navigation/parseTopLevelPages'
+import { ContentTypePathPrefixesMap } from '@/src/services/navigation/parseContentTypePathPrefixes'
+import { PagePathsMap } from '@/src/services/navigation/parseTopLevelPages'
+import { NavigationObject } from '@/src/services/navigation/typesNavigation'
 
-type GeneralContextType = Omit<GeneralQuery, 'navigation' | 'topLevelPages'> & {
+type GeneralContextType = GeneralQuery & {
   pagePathsMap: PagePathsMap
   contentTypePathPrefixesMap: ContentTypePathPrefixesMap
 }
 
 const GeneralContext = createContext<GeneralContextType | null>(null)
 
+// pagePathsMap is used to get path for Pages from their slug
+// contentTypePathPrefixesMap is used to get path of Content Type's parent page, e.g. path prefix for Articles or Documents etc.
+type GeneralContextProviderProps = {
+  children: ReactNode
+  general: GeneralQuery
+  navigation: NavigationObject
+}
+
 export const GeneralContextProvider = ({
   children,
   general,
-}: {
-  children: ReactNode
-  general: GeneralQuery
-}) => {
-  // pagePathsMap is used to get path for Pages from their slug
-  const { pagePathsMap } = useMemo(() => {
-    return parseTopLevelPages(general.topLevelPages?.data ?? [], '')
-  }, [general.topLevelPages?.data])
-
-  // contentTypePathPrefixesMap is used to get path of Content Type's parent page, e.g. path prefix for Articles or Documents etc.
-  const { contentTypePathPrefixesMap } = useMemo(() => {
-    return parseContentTypePathPrefixes(general.navigation, pagePathsMap)
-  }, [general.navigation, pagePathsMap])
-
+  navigation,
+}: GeneralContextProviderProps) => {
   return (
-    <GeneralContext.Provider value={{ ...general, pagePathsMap, contentTypePathPrefixesMap }}>
+    <GeneralContext.Provider value={{ ...general, ...navigation }}>
       {children}
     </GeneralContext.Provider>
   )

--- a/next/src/services/graphql/api.ts
+++ b/next/src/services/graphql/api.ts
@@ -14504,57 +14504,6 @@ export type OpeningTimeEntityFragment = {
   } | null
 }
 
-export type ParentPageFragment = { __typename?: 'Page'; slug: string; title: string }
-
-export type PageParentPagesFragment = {
-  __typename?: 'PageEntity'
-  attributes?: {
-    __typename?: 'Page'
-    slug: string
-    title: string
-    parentPage?: {
-      __typename?: 'PageEntityResponse'
-      data?: {
-        __typename?: 'PageEntity'
-        attributes?: {
-          __typename?: 'Page'
-          slug: string
-          title: string
-          parentPage?: {
-            __typename?: 'PageEntityResponse'
-            data?: {
-              __typename?: 'PageEntity'
-              attributes?: {
-                __typename?: 'Page'
-                slug: string
-                title: string
-                parentPage?: {
-                  __typename?: 'PageEntityResponse'
-                  data?: {
-                    __typename?: 'PageEntity'
-                    attributes?: {
-                      __typename?: 'Page'
-                      slug: string
-                      title: string
-                      parentPage?: {
-                        __typename?: 'PageEntityResponse'
-                        data?: {
-                          __typename?: 'PageEntity'
-                          attributes?: { __typename?: 'Page'; slug: string; title: string } | null
-                        } | null
-                      } | null
-                    } | null
-                  } | null
-                } | null
-              } | null
-            } | null
-          } | null
-        } | null
-      } | null
-    } | null
-  } | null
-}
-
 export type ChildPageFragment = { __typename?: 'Page'; slug: string; title: string }
 
 export type PageChildPagesFragment = {
@@ -14630,6 +14579,7 @@ export type PageEntityFragment = {
     __typename?: 'Page'
     perex?: string | null
     alias?: string | null
+    updatedAt?: any | null
     title: string
     slug: string
     header?: Array<
@@ -16693,6 +16643,7 @@ export type PagesQuery = {
         __typename?: 'Page'
         perex?: string | null
         alias?: string | null
+        updatedAt?: any | null
         title: string
         slug: string
         header?: Array<
@@ -18763,6 +18714,7 @@ export type PageBySlugQuery = {
         __typename?: 'Page'
         perex?: string | null
         alias?: string | null
+        updatedAt?: any | null
         title: string
         slug: string
         header?: Array<
@@ -20812,50 +20764,6 @@ export type PageBySlugQuery = {
           | { __typename: 'Error' }
           | null
         > | null
-        parentPage?: {
-          __typename?: 'PageEntityResponse'
-          data?: {
-            __typename?: 'PageEntity'
-            attributes?: {
-              __typename?: 'Page'
-              slug: string
-              title: string
-              parentPage?: {
-                __typename?: 'PageEntityResponse'
-                data?: {
-                  __typename?: 'PageEntity'
-                  attributes?: {
-                    __typename?: 'Page'
-                    slug: string
-                    title: string
-                    parentPage?: {
-                      __typename?: 'PageEntityResponse'
-                      data?: {
-                        __typename?: 'PageEntity'
-                        attributes?: {
-                          __typename?: 'Page'
-                          slug: string
-                          title: string
-                          parentPage?: {
-                            __typename?: 'PageEntityResponse'
-                            data?: {
-                              __typename?: 'PageEntity'
-                              attributes?: {
-                                __typename?: 'Page'
-                                slug: string
-                                title: string
-                              } | null
-                            } | null
-                          } | null
-                        } | null
-                      } | null
-                    } | null
-                  } | null
-                } | null
-              } | null
-            } | null
-          } | null
-        } | null
       } | null
     }>
   } | null
@@ -24736,48 +24644,6 @@ export const MenuEntityFragmentDoc = gql`
   }
   ${MenuFragmentDoc}
 `
-export const ParentPageFragmentDoc = gql`
-  fragment ParentPage on Page {
-    slug
-    title
-  }
-`
-export const PageParentPagesFragmentDoc = gql`
-  fragment PageParentPages on PageEntity {
-    attributes {
-      ...ParentPage
-      parentPage {
-        data {
-          attributes {
-            ...ParentPage
-            parentPage {
-              data {
-                attributes {
-                  ...ParentPage
-                  parentPage {
-                    data {
-                      attributes {
-                        ...ParentPage
-                        parentPage {
-                          data {
-                            attributes {
-                              ...ParentPage
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  ${ParentPageFragmentDoc}
-`
 export const ChildPageFragmentDoc = gql`
   fragment ChildPage on Page {
     slug
@@ -25507,7 +25373,7 @@ export const PageSectionsFragmentDoc = gql`
 `
 export const PageEntityFragmentDoc = gql`
   fragment PageEntity on PageEntity {
-    ...PageSlugEntity
+    ...PageCardEntity
     attributes {
       perex
       alias
@@ -25519,7 +25385,7 @@ export const PageEntityFragmentDoc = gql`
       }
     }
   }
-  ${PageSlugEntityFragmentDoc}
+  ${PageCardEntityFragmentDoc}
   ${HeaderSectionsFragmentDoc}
   ${PageSectionsFragmentDoc}
 `
@@ -25882,12 +25748,10 @@ export const PageBySlugDocument = gql`
     pages(filters: { slug: { eq: $slug } }, locale: $locale) {
       data {
         ...PageEntity
-        ...PageParentPages
       }
     }
   }
   ${PageEntityFragmentDoc}
-  ${PageParentPagesFragmentDoc}
 `
 export const PageRedirectByAliasDocument = gql`
   query PageRedirectByAlias($alias: String!, $locale: I18NLocaleCode!) {

--- a/next/src/services/graphql/api.ts
+++ b/next/src/services/graphql/api.ts
@@ -4906,11 +4906,11 @@ export type NavigationEntityFragment = {
   } | null
 }
 
-export type GeneralQueryVariables = Exact<{
+export type NavigationQueryVariables = Exact<{
   locale: Scalars['I18NLocaleCode']['input']
 }>
 
-export type GeneralQuery = {
+export type NavigationQuery = {
   __typename?: 'Query'
   navigation?: {
     __typename?: 'NavigationEntityResponse'
@@ -5021,6 +5021,14 @@ export type GeneralQuery = {
       } | null
     }>
   } | null
+}
+
+export type GeneralQueryVariables = Exact<{
+  locale: Scalars['I18NLocaleCode']['input']
+}>
+
+export type GeneralQuery = {
+  __typename?: 'Query'
   footer?: {
     __typename?: 'FooterEntityResponse'
     data?: {
@@ -25717,8 +25725,8 @@ export const ServiceCategoryBySlugDocument = gql`
   }
   ${ServiceCategoryEntityFragmentDoc}
 `
-export const GeneralDocument = gql`
-  query General($locale: I18NLocaleCode!) {
+export const NavigationDocument = gql`
+  query Navigation($locale: I18NLocaleCode!) {
     navigation(locale: $locale) {
       data {
         ...NavigationEntity
@@ -25729,6 +25737,12 @@ export const GeneralDocument = gql`
         ...PageChildPages
       }
     }
+  }
+  ${NavigationEntityFragmentDoc}
+  ${PageChildPagesFragmentDoc}
+`
+export const GeneralDocument = gql`
+  query General($locale: I18NLocaleCode!) {
     footer(locale: $locale) {
       data {
         ...FooterEntity
@@ -25740,8 +25754,6 @@ export const GeneralDocument = gql`
       }
     }
   }
-  ${NavigationEntityFragmentDoc}
-  ${PageChildPagesFragmentDoc}
   ${FooterEntityFragmentDoc}
   ${MenuEntityFragmentDoc}
 `
@@ -26106,6 +26118,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             ...wrappedRequestHeaders,
           }),
         'ServiceCategoryBySlug',
+        'query',
+        variables,
+      )
+    },
+    Navigation(
+      variables: NavigationQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<NavigationQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<NavigationQuery>(NavigationDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'Navigation',
         'query',
         variables,
       )

--- a/next/src/services/graphql/queries/_general.gql
+++ b/next/src/services/graphql/queries/_general.gql
@@ -28,7 +28,7 @@ fragment NavigationEntity on NavigationEntity {
   }
 }
 
-query General($locale: I18NLocaleCode!) {
+query Navigation($locale: I18NLocaleCode!) {
   navigation(locale: $locale) {
     data {
       ...NavigationEntity
@@ -39,6 +39,9 @@ query General($locale: I18NLocaleCode!) {
       ...PageChildPages
     }
   }
+}
+
+query General($locale: I18NLocaleCode!) {
   footer(locale: $locale) {
     data {
       ...FooterEntity

--- a/next/src/services/graphql/queries/pages.gql
+++ b/next/src/services/graphql/queries/pages.gql
@@ -1,42 +1,3 @@
-fragment ParentPage on Page {
-  slug
-  title
-}
-
-fragment PageParentPages on PageEntity {
-  attributes {
-    ...ParentPage
-    parentPage {
-      data {
-        attributes {
-          ...ParentPage
-          parentPage {
-            data {
-              attributes {
-                ...ParentPage
-                parentPage {
-                  data {
-                    attributes {
-                      ...ParentPage
-                      parentPage {
-                        data {
-                          attributes {
-                            ...ParentPage
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
 fragment ChildPage on Page {
   slug
   title
@@ -98,7 +59,7 @@ fragment PageCardEntity on PageEntity {
 }
 
 fragment PageEntity on PageEntity {
-  ...PageSlugEntity
+  ...PageCardEntity
   attributes {
     perex
     alias
@@ -123,7 +84,6 @@ query PageBySlug($slug: String!, $locale: I18NLocaleCode!) {
   pages(filters: { slug: { eq: $slug } }, locale: $locale) {
     data {
       ...PageEntity
-      ...PageParentPages
     }
   }
 }

--- a/next/src/services/navigation/fetchNavigation.ts
+++ b/next/src/services/navigation/fetchNavigation.ts
@@ -1,3 +1,5 @@
+import { fetchNonCachedNavigation } from '@/src/services/navigation/fetchNonCachedNavigation'
+import { fetchNonCachedNavigationFromApi } from '@/src/services/navigation/fetchNonCachedNavigationFromApi'
 import { ContentTypePathPrefixesMap } from '@/src/services/navigation/parseContentTypePathPrefixes'
 import { PagePathsMap } from '@/src/services/navigation/parseTopLevelPages'
 import { NavigationConfig, NavigationObject } from '@/src/services/navigation/typesNavigation'
@@ -13,29 +15,43 @@ let cache: {
   }
 } | null = null
 
-const fetchNonCached = async <Config extends NavigationConfig>(config: Config) => {
-  /**
-   * The request is handled on server, so we have to use http instead of https.
-   * `pathname` contains leading "/"
-   */
-  const fetchUrl = `http://${config.host}/api/navigation`
-
-  const response = await fetch(fetchUrl)
-
-  if (!response.ok) {
-    throw new Error(await response.text())
-  }
-
-  return response.json()
-}
-
+/**
+ * Fetches and cache navigation data directly from the Strapi client.
+ * Use this function in getStaticProps or getServerSideProps.
+ *
+ * @param config
+ */
 export const fetchNavigation = async <Config extends NavigationConfig>(config: Config) => {
   if (cache?.timestamp && cache.timestamp + config.cacheTtl > Date.now()) {
     return cache.value
   }
 
   // TODO types - make it type safe, now it's any
-  const navigation = (await fetchNonCached(config)) as NavigationObject
+  const navigation = (await fetchNonCachedNavigation()) as NavigationObject
+
+  const { contentTypePathPrefixesMap, pagePathsMap } = navigation
+
+  const value = { contentTypePathPrefixesMap, pagePathsMap }
+  cache = { timestamp: Date.now(), value }
+
+  return value
+}
+
+/**
+ * Fetches and cache navigation data from the Strapi client via API endpoint.
+ * Use this function in middleware.
+ * It's not possible to use graphql client in middleware, because it depends on node runtime and middleware uses edge runtime,
+ * so we fetch data through API endpoint.
+ *
+ * @param config
+ */
+export const fetchNavigationFromApi = async <Config extends NavigationConfig>(config: Config) => {
+  if (cache?.timestamp && cache.timestamp + config.cacheTtl > Date.now()) {
+    return cache.value
+  }
+
+  // TODO types - make it type safe, now it's any
+  const navigation = (await fetchNonCachedNavigationFromApi(config)) as NavigationObject
 
   const { contentTypePathPrefixesMap, pagePathsMap } = navigation
 

--- a/next/src/services/navigation/fetchNavigation.ts
+++ b/next/src/services/navigation/fetchNavigation.ts
@@ -1,5 +1,6 @@
 import { ContentTypePathPrefixesMap } from '@/src/services/navigation/parseContentTypePathPrefixes'
-import { NavigationConfig } from '@/src/services/navigation/typesNavigation'
+import { PagePathsMap } from '@/src/services/navigation/parseTopLevelPages'
+import { NavigationConfig, NavigationObject } from '@/src/services/navigation/typesNavigation'
 
 // Inspired by City Library - Navikronos custom plugin
 // https://github.com/bratislava/mestskakniznica.sk/blob/dfef31c799e1a903af4fa30aa1be5c3f27ae5418/next/navikronos/internal/fetch.ts
@@ -8,6 +9,7 @@ let cache: {
   timestamp: number
   value: {
     contentTypePathPrefixesMap: ContentTypePathPrefixesMap
+    pagePathsMap: PagePathsMap
   }
 } | null = null
 
@@ -33,9 +35,11 @@ export const fetchNavigation = async <Config extends NavigationConfig>(config: C
   }
 
   // TODO types - make it type safe, now it's any
-  const { contentTypePathPrefixesMap } = await fetchNonCached(config)
+  const navigation = (await fetchNonCached(config)) as NavigationObject
 
-  const value = { contentTypePathPrefixesMap }
+  const { contentTypePathPrefixesMap, pagePathsMap } = navigation
+
+  const value = { contentTypePathPrefixesMap, pagePathsMap }
   cache = { timestamp: Date.now(), value }
 
   return value

--- a/next/src/services/navigation/fetchNavigation.ts
+++ b/next/src/services/navigation/fetchNavigation.ts
@@ -11,12 +11,12 @@ let cache: {
   }
 } | null = null
 
-const fetchNonCached = async (host: string) => {
+const fetchNonCached = async <Config extends NavigationConfig>(config: Config) => {
   /**
    * The request is handled on server, so we have to use http instead of https.
    * `pathname` contains leading "/"
    */
-  const fetchUrl = `http://${host}/api/navigation`
+  const fetchUrl = `http://${config.host}/api/navigation`
 
   const response = await fetch(fetchUrl)
 
@@ -27,16 +27,13 @@ const fetchNonCached = async (host: string) => {
   return response.json()
 }
 
-export const fetchNavigation = async <Config extends NavigationConfig>(
-  config: Config,
-  host: string,
-) => {
+export const fetchNavigation = async <Config extends NavigationConfig>(config: Config) => {
   if (cache?.timestamp && cache.timestamp + config.cacheTtl > Date.now()) {
     return cache.value
   }
 
-  // TODO types
-  const { contentTypePathPrefixesMap } = await fetchNonCached(host)
+  // TODO types - make it type safe, now it's any
+  const { contentTypePathPrefixesMap } = await fetchNonCached(config)
 
   const value = { contentTypePathPrefixesMap }
   cache = { timestamp: Date.now(), value }

--- a/next/src/services/navigation/fetchNonCachedNavigation.ts
+++ b/next/src/services/navigation/fetchNonCachedNavigation.ts
@@ -1,0 +1,23 @@
+import { client } from '@/src/services/graphql'
+import { parseContentTypePathPrefixes } from '@/src/services/navigation/parseContentTypePathPrefixes'
+import { parseTopLevelPages } from '@/src/services/navigation/parseTopLevelPages'
+
+// Inspired by City Library - Navikronos custom plugin
+// https://github.com/bratislava/mestskakniznica.sk/blob/dfef31c799e1a903af4fa30aa1be5c3f27ae5418/next/navikronos/internal/fetch.ts
+
+/**
+ * Fetches and parses navigation data from the Strapi client.
+ * It's wrapped into function to use it both directly and in API handler.
+ *
+ */
+export const fetchNonCachedNavigation = async () => {
+  const { navigation, topLevelPages } = await client.Navigation({ locale: 'sk' }) // TODO locale
+
+  const { pagePathsMap } = parseTopLevelPages(topLevelPages?.data ?? [])
+  const { contentTypePathPrefixesMap } = parseContentTypePathPrefixes(navigation, pagePathsMap)
+
+  return {
+    contentTypePathPrefixesMap,
+    pagePathsMap,
+  }
+}

--- a/next/src/services/navigation/fetchNonCachedNavigationFromApi.ts
+++ b/next/src/services/navigation/fetchNonCachedNavigationFromApi.ts
@@ -1,0 +1,19 @@
+import { NavigationConfig } from '@/src/services/navigation/typesNavigation'
+
+export const fetchNonCachedNavigationFromApi = async <Config extends NavigationConfig>(
+  config: Config,
+) => {
+  /**
+   * The request is handled on server, so we have to use http instead of https.
+   * `pathname` contains leading "/"
+   */
+  const fetchUrl = `http://${config.host}/api/navigation`
+
+  const response = await fetch(fetchUrl)
+
+  if (!response.ok) {
+    throw new Error(await response.text())
+  }
+
+  return response.json()
+}

--- a/next/src/services/navigation/getNavigationMiddleware.ts
+++ b/next/src/services/navigation/getNavigationMiddleware.ts
@@ -17,7 +17,7 @@ import { NavigationConfig } from '@/src/services/navigation/typesNavigation'
 export const getNavigationMiddleware = (config: NavigationConfig) => {
   // eslint-disable-next-line consistent-return,sonarjs/cognitive-complexity
   return async (request: NextRequest) => {
-    const { contentTypePathPrefixesMap } = await fetchNavigation(config, request.nextUrl.host)
+    const { contentTypePathPrefixesMap } = await fetchNavigation(config)
 
     const pathnameString = request.nextUrl.pathname
     const pathname = pathnameString.split('/')

--- a/next/src/services/navigation/getNavigationMiddleware.ts
+++ b/next/src/services/navigation/getNavigationMiddleware.ts
@@ -1,15 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-import { fetchNavigation } from '@/src/services/navigation/fetchNavigation'
+import { fetchNavigationFromApi } from '@/src/services/navigation/fetchNavigation'
 import { NavigationConfig } from '@/src/services/navigation/typesNavigation'
 
 // Inspired by City Library - Navikronos custom plugin
 // https://github.com/bratislava/mestskakniznica.sk/blob/dfef31c799e1a903af4fa30aa1be5c3f27ae5418/next/navikronos/getNavikronosMiddleware.ts
 
 /**
- * This middleware rewrites path based on given path and data from Strapi "Sitemap" content type.
- * The logic of rewrites lives in api handler, to be able to use our graphql client.
- * (it's not possible to use graphql client in middleware, because it depends on node runtime and middleware uses edge runtime)
+ * This middleware rewrites path based on given path and data from Strapi "Navigation" content type.
  *
  * @param config
  */
@@ -17,7 +15,7 @@ import { NavigationConfig } from '@/src/services/navigation/typesNavigation'
 export const getNavigationMiddleware = (config: NavigationConfig) => {
   // eslint-disable-next-line consistent-return,sonarjs/cognitive-complexity
   return async (request: NextRequest) => {
-    const { contentTypePathPrefixesMap } = await fetchNavigation(config)
+    const { contentTypePathPrefixesMap } = await fetchNavigationFromApi(config)
 
     const pathnameString = request.nextUrl.pathname
     const pathname = pathnameString.split('/')

--- a/next/src/services/navigation/navigationConfig.ts
+++ b/next/src/services/navigation/navigationConfig.ts
@@ -1,0 +1,7 @@
+import { environment } from '@/src/environment'
+import { NavigationConfig } from '@/src/services/navigation/typesNavigation'
+
+export const navigationConfig: NavigationConfig = {
+  cacheTtl: 10_000,
+  host: environment.nextHost,
+}

--- a/next/src/services/navigation/parseContentTypePathPrefixes.ts
+++ b/next/src/services/navigation/parseContentTypePathPrefixes.ts
@@ -23,22 +23,23 @@ export const parseContentTypePathPrefixes = (
   const servicesParentPageSlug = servicesParentPage?.data?.attributes?.slug
   const workshopsParentPageSlug = workshopsParentPage?.data?.attributes?.slug
 
+  // Using null to make the object serializable
   const contentTypePathPrefixesMap = {
     article: articlesParentPageSlug
-      ? pagePathsMap.get(articlesParentPageSlug)?.path
-      : articlesParentPageSlug,
+      ? pagePathsMap[articlesParentPageSlug]?.path
+      : articlesParentPageSlug ?? null,
     document: documentsParentPageSlug
-      ? pagePathsMap.get(documentsParentPageSlug)?.path
-      : documentsParentPageSlug,
+      ? pagePathsMap[documentsParentPageSlug]?.path
+      : documentsParentPageSlug ?? null,
     faqCategory: faqCategoriesParentPageSlug
-      ? pagePathsMap.get(faqCategoriesParentPageSlug)?.path
-      : faqCategoriesParentPageSlug,
+      ? pagePathsMap[faqCategoriesParentPageSlug]?.path
+      : faqCategoriesParentPageSlug ?? null,
     service: servicesParentPageSlug
-      ? pagePathsMap.get(servicesParentPageSlug)?.path
-      : servicesParentPageSlug,
+      ? pagePathsMap[servicesParentPageSlug]?.path
+      : servicesParentPageSlug ?? null,
     workshop: workshopsParentPageSlug
-      ? pagePathsMap.get(workshopsParentPageSlug)?.path
-      : workshopsParentPageSlug,
+      ? pagePathsMap[workshopsParentPageSlug]?.path
+      : workshopsParentPageSlug ?? null,
   }
 
   return { contentTypePathPrefixesMap }

--- a/next/src/services/navigation/parseContentTypePathPrefixes.ts
+++ b/next/src/services/navigation/parseContentTypePathPrefixes.ts
@@ -1,4 +1,4 @@
-import { GeneralQuery } from '@/src/services/graphql/api'
+import { NavigationQuery } from '@/src/services/graphql/api'
 import { PagePathsMap } from '@/src/services/navigation/parseTopLevelPages'
 
 export type ContentTypePathPrefixesMap = ReturnType<
@@ -6,7 +6,7 @@ export type ContentTypePathPrefixesMap = ReturnType<
 >['contentTypePathPrefixesMap']
 
 export const parseContentTypePathPrefixes = (
-  navigation: GeneralQuery['navigation'],
+  navigation: NavigationQuery['navigation'],
   pagePathsMap: PagePathsMap,
 ) => {
   const {

--- a/next/src/services/navigation/parseTopLevelPages.ts
+++ b/next/src/services/navigation/parseTopLevelPages.ts
@@ -1,7 +1,7 @@
 import { PageChildPagesFragment } from '@/src/services/graphql/api'
 import { isDefined } from '@/src/utils/isDefined'
 
-const pagePathsMap = new Map<string, { label: string; path: string }>()
+const pagePathsMap: { [key: string]: { title: string; path: string } | undefined } = {}
 
 export type PagePathsMap = typeof pagePathsMap
 
@@ -14,7 +14,7 @@ export const parseTopLevelPages = (pages: PageChildPagesFragment[], parentPath: 
     const title = page.attributes?.title
 
     if (slug && title) {
-      pagePathsMap.set(slug, { label: title, path: `${parentPath}/${slug}` })
+      pagePathsMap[slug] = { title, path: `${parentPath}/${slug}` }
     }
     // eslint-disable-next-line unicorn/no-array-callback-reference
     const childPages = page.attributes?.childPages?.data.filter(isDefined)

--- a/next/src/services/navigation/typesNavigation.ts
+++ b/next/src/services/navigation/typesNavigation.ts
@@ -1,3 +1,12 @@
+import { ContentTypePathPrefixesMap } from '@/src/services/navigation/parseContentTypePathPrefixes'
+import { PagePathsMap } from '@/src/services/navigation/parseTopLevelPages'
+
+export type NavigationObject = {
+  contentTypePathPrefixesMap: ContentTypePathPrefixesMap
+  pagePathsMap: PagePathsMap
+}
+
 export type NavigationConfig = {
   cacheTtl: number
+  host: string
 }

--- a/next/src/utils/getPageBreadcrumbs.ts
+++ b/next/src/utils/getPageBreadcrumbs.ts
@@ -1,4 +1,4 @@
-import { PageParentPagesFragment } from '@/src/services/graphql/api'
+import { PagePathsMap } from '@/src/services/navigation/parseTopLevelPages'
 
 export type Breadcrumb = {
   title: string
@@ -7,33 +7,14 @@ export type Breadcrumb = {
 
 // Based on bratislava.sk: https://github.com/bratislava/bratislava.sk/blob/master/next/utils/pageUtils_Deprecated.ts#L93
 
-export const getPageBreadcrumbs = (
-  page: PageParentPagesFragment | null | undefined,
-): Breadcrumb[] => {
-  const current = page
-  if (!current) {
-    return []
-  }
-
-  const pages = [current]
-
-  let parentPage = current?.attributes?.parentPage
-  while (parentPage?.data?.attributes) {
-    pages.push(parentPage.data)
-    parentPage = parentPage.data.attributes.parentPage
-  }
-
+export const getPageBreadcrumbs = (path: string, pagePathsMap: PagePathsMap): Breadcrumb[] => {
   const breadcrumbs: Breadcrumb[] = []
 
-  pages.reverse().forEach((pageInner) => {
-    const previousBreadcrumb = breadcrumbs.at(-1)
+  const pathSegments = path.split('/') ?? []
 
-    breadcrumbs.push({
-      title: pageInner.attributes?.title ?? '',
-      path: pageInner.attributes?.slug
-        ? `${previousBreadcrumb ? previousBreadcrumb.path : ''}/${pageInner.attributes.slug}`
-        : null,
-    })
+  pathSegments.forEach((segment) => {
+    const crumb = pagePathsMap[segment]
+    if (crumb) breadcrumbs.push(crumb)
   })
 
   return breadcrumbs

--- a/next/src/utils/useGetFullPath.ts
+++ b/next/src/utils/useGetFullPath.ts
@@ -43,7 +43,7 @@ export const getFullPathFn = (
 
   // TODO Rewrite to cleaner code
   if (entity.__typename === 'PageEntity') {
-    return pagePathsMap.get(slug)?.path ?? `#notFound`
+    return pagePathsMap[slug]?.path ?? `#notFound`
   }
 
   if (entity.__typename === 'ArticleEntity' && contentTypePathPrefixesMap.article) {

--- a/strapi/config/plugins.meilisearch.config.ts
+++ b/strapi/config/plugins.meilisearch.config.ts
@@ -71,33 +71,6 @@ const meilisearchConfig = {
     indexName: 'search_index',
     entriesQuery: {
       locale: 'all',
-      populate: {
-        // Similar to graphql fragment PageParentPages, we need to
-        // reach several parent levels in order to construct the path to the page
-        parentPage: {
-          fields: ['title', 'slug'],
-          populate: {
-            parentPage: {
-              fields: ['title', 'slug'],
-              populate: {
-                parentPage: {
-                  fields: ['title', 'slug'],
-                  populate: {
-                    parentPage: {
-                      fields: ['title', 'slug'],
-                      populate: {
-                        parentPage: {
-                          fields: ['title', 'slug'],
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
     },
     settings: searchIndexSettings,
     transformEntry: ({ entry }) => wrapSearchIndexEntry('page', entry),


### PR DESCRIPTION
- use cached `fetchNavigation` everywhere instead of strapi `client.General` query
- rewrite breadcrumbs to be generated from path and `pagesPathMap` and remove redundant `parentPage` recursive chain

Tested locally, all content types linking and breadcrumbs work correctly.

~~! Deployment hosts needs to be tested.~~
Tested successfully also deployed on dev.

Commit by commit