### PR TITLE
#413 Opening hours section

### DIFF
--- a/next/src/services/graphql/api.ts
+++ b/next/src/services/graphql/api.ts
@@ -2879,7 +2879,6 @@ export type OpeningTime = {
   __typename?: 'OpeningTime'
   branches?: Maybe<BranchRelationResponseCollection>
   createdAt?: Maybe<Scalars['DateTime']['output']>
-  internalName: Scalars['String']['output']
   openingHours?: Maybe<Array<Maybe<ComponentItemsOpeningHoursItem>>>
   updatedAt?: Maybe<Scalars['DateTime']['output']>
 }
@@ -5328,7 +5327,6 @@ export type GeneralQuery = {
                         id?: string | null
                         attributes?: {
                           __typename?: 'OpeningTime'
-                          internalName: string
                           openingHours?: Array<{
                             __typename?: 'ComponentItemsOpeningHoursItem'
                             label: string
@@ -6509,7 +6507,6 @@ export type BranchesSectionFragment = {
             id?: string | null
             attributes?: {
               __typename?: 'OpeningTime'
-              internalName: string
               openingHours?: Array<{
                 __typename?: 'ComponentItemsOpeningHoursItem'
                 label: string
@@ -8065,7 +8062,6 @@ export type OpeningTimesSectionFragment = {
         id?: string | null
         attributes?: {
           __typename?: 'OpeningTime'
-          internalName: string
           openingHours?: Array<{
             __typename?: 'ComponentItemsOpeningHoursItem'
             label: string
@@ -8505,7 +8501,6 @@ type PageSections_ComponentSectionsBranches_Fragment = {
             id?: string | null
             attributes?: {
               __typename?: 'OpeningTime'
-              internalName: string
               openingHours?: Array<{
                 __typename?: 'ComponentItemsOpeningHoursItem'
                 label: string
@@ -9433,7 +9428,6 @@ type PageSections_ComponentSectionsOpeningTimes_Fragment = {
         id?: string | null
         attributes?: {
           __typename?: 'OpeningTime'
-          internalName: string
           openingHours?: Array<{
             __typename?: 'ComponentItemsOpeningHoursItem'
             label: string
@@ -10588,7 +10582,6 @@ export type BranchEntityFragment = {
         id?: string | null
         attributes?: {
           __typename?: 'OpeningTime'
-          internalName: string
           openingHours?: Array<{
             __typename?: 'ComponentItemsOpeningHoursItem'
             label: string
@@ -10652,7 +10645,6 @@ export type BranchesQuery = {
             id?: string | null
             attributes?: {
               __typename?: 'OpeningTime'
-              internalName: string
               openingHours?: Array<{
                 __typename?: 'ComponentItemsOpeningHoursItem'
                 label: string
@@ -12558,7 +12550,6 @@ export type KoloHomepageSectionFragment = {
             id?: string | null
             attributes?: {
               __typename?: 'OpeningTime'
-              internalName: string
               openingHours?: Array<{
                 __typename?: 'ComponentItemsOpeningHoursItem'
                 label: string
@@ -13314,7 +13305,6 @@ export type HomepageEntityFragment = {
                 id?: string | null
                 attributes?: {
                   __typename?: 'OpeningTime'
-                  internalName: string
                   openingHours?: Array<{
                     __typename?: 'ComponentItemsOpeningHoursItem'
                     label: string
@@ -14089,7 +14079,6 @@ export type HomepageQuery = {
                     id?: string | null
                     attributes?: {
                       __typename?: 'OpeningTime'
-                      internalName: string
                       openingHours?: Array<{
                         __typename?: 'ComponentItemsOpeningHoursItem'
                         label: string
@@ -14392,7 +14381,6 @@ export type MenuLinkFragment = {
             id?: string | null
             attributes?: {
               __typename?: 'OpeningTime'
-              internalName: string
               openingHours?: Array<{
                 __typename?: 'ComponentItemsOpeningHoursItem'
                 label: string
@@ -14494,7 +14482,6 @@ export type MenuSectionFragment = {
               id?: string | null
               attributes?: {
                 __typename?: 'OpeningTime'
-                internalName: string
                 openingHours?: Array<{
                   __typename?: 'ComponentItemsOpeningHoursItem'
                   label: string
@@ -14601,7 +14588,6 @@ export type MenuItemFragment = {
                 id?: string | null
                 attributes?: {
                   __typename?: 'OpeningTime'
-                  internalName: string
                   openingHours?: Array<{
                     __typename?: 'ComponentItemsOpeningHoursItem'
                     label: string
@@ -14926,7 +14912,6 @@ export type MenuFragment = {
                   id?: string | null
                   attributes?: {
                     __typename?: 'OpeningTime'
-                    internalName: string
                     openingHours?: Array<{
                       __typename?: 'ComponentItemsOpeningHoursItem'
                       label: string
@@ -15262,7 +15247,6 @@ export type MenuEntityFragment = {
                     id?: string | null
                     attributes?: {
                       __typename?: 'OpeningTime'
-                      internalName: string
                       openingHours?: Array<{
                         __typename?: 'ComponentItemsOpeningHoursItem'
                         label: string
@@ -15551,7 +15535,6 @@ export type OpeningTimeEntityFragment = {
   id?: string | null
   attributes?: {
     __typename?: 'OpeningTime'
-    internalName: string
     openingHours?: Array<{
       __typename?: 'ComponentItemsOpeningHoursItem'
       label: string
@@ -16185,7 +16168,6 @@ export type PageEntityFragment = {
                     id?: string | null
                     attributes?: {
                       __typename?: 'OpeningTime'
-                      internalName: string
                       openingHours?: Array<{
                         __typename?: 'ComponentItemsOpeningHoursItem'
                         label: string
@@ -17156,7 +17138,6 @@ export type PageEntityFragment = {
                 id?: string | null
                 attributes?: {
                   __typename?: 'OpeningTime'
-                  internalName: string
                   openingHours?: Array<{
                     __typename?: 'ComponentItemsOpeningHoursItem'
                     label: string
@@ -18457,7 +18438,6 @@ export type PagesQuery = {
                         id?: string | null
                         attributes?: {
                           __typename?: 'OpeningTime'
-                          internalName: string
                           openingHours?: Array<{
                             __typename?: 'ComponentItemsOpeningHoursItem'
                             label: string
@@ -19432,7 +19412,6 @@ export type PagesQuery = {
                     id?: string | null
                     attributes?: {
                       __typename?: 'OpeningTime'
-                      internalName: string
                       openingHours?: Array<{
                         __typename?: 'ComponentItemsOpeningHoursItem'
                         label: string
@@ -20736,7 +20715,6 @@ export type PageBySlugQuery = {
                         id?: string | null
                         attributes?: {
                           __typename?: 'OpeningTime'
-                          internalName: string
                           openingHours?: Array<{
                             __typename?: 'ComponentItemsOpeningHoursItem'
                             label: string
@@ -21711,7 +21689,6 @@ export type PageBySlugQuery = {
                     id?: string | null
                     attributes?: {
                       __typename?: 'OpeningTime'
-                      internalName: string
                       openingHours?: Array<{
                         __typename?: 'ComponentItemsOpeningHoursItem'
                         label: string
@@ -26441,7 +26418,6 @@ export const OpeningTimeEntityFragmentDoc = gql`
   fragment OpeningTimeEntity on OpeningTimeEntity {
     id
     attributes {
-      internalName
       openingHours {
         ...OpeningHoursItem
       }

--- a/next/src/services/graphql/queries/opening-times.gql
+++ b/next/src/services/graphql/queries/opening-times.gql
@@ -3,11 +3,9 @@ fragment OpeningHoursItem on ComponentItemsOpeningHoursItem {
   value
 }
 
-
 fragment OpeningTimeEntity on OpeningTimeEntity {
   id
   attributes {
-    internalName
     openingHours {
       ...OpeningHoursItem
     }

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -2730,7 +2730,6 @@ type NavigationRelationResponseCollection {
 type OpeningTime {
   branches(filters: BranchFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): BranchRelationResponseCollection
   createdAt: DateTime
-  internalName: String!
   openingHours(filters: ComponentItemsOpeningHoursItemFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): [ComponentItemsOpeningHoursItem]
   updatedAt: DateTime
 }

--- a/strapi/src/api/opening-time/content-types/opening-time/schema.json
+++ b/strapi/src/api/opening-time/content-types/opening-time/schema.json
@@ -14,7 +14,8 @@
   "attributes": {
     "internalName": {
       "type": "string",
-      "required": true
+      "required": false,
+      "private": true
     },
     "branches": {
       "type": "relation",

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -1,58 +1,5 @@
 import type { Schema, Attribute } from '@strapi/strapi'
 
-export interface MenuMenuSection extends Schema.Component {
-  collectionName: 'components_menu_menu_sections'
-  info: {
-    displayName: 'menu section'
-    description: ''
-  }
-  attributes: {
-    label: Attribute.String & Attribute.Required
-    links: Attribute.Component<'menu.menu-link', true>
-    colSpan: Attribute.Integer &
-      Attribute.Required &
-      Attribute.SetMinMax<
-        {
-          min: 0
-          max: 3
-        },
-        number
-      > &
-      Attribute.DefaultTo<1>
-    multicolumnBehaviour: Attribute.Enumeration<['fullwidth', 'split equally']>
-    hasDividers: Attribute.Boolean & Attribute.Required & Attribute.DefaultTo<false>
-    specialSectionType: Attribute.Enumeration<['latest articles']>
-  }
-}
-
-export interface MenuMenuLink extends Schema.Component {
-  collectionName: 'components_menu_menu_link'
-  info: {
-    displayName: 'menu link'
-    description: ''
-  }
-  attributes: {
-    label: Attribute.String
-    url: Attribute.String
-    page: Attribute.Relation<'menu.menu-link', 'oneToOne', 'api::page.page'>
-    branch: Attribute.Relation<'menu.menu-link', 'oneToOne', 'api::branch.branch'>
-    service: Attribute.Relation<'menu.menu-link', 'oneToOne', 'api::service.service'>
-    workshop: Attribute.Relation<'menu.menu-link', 'oneToOne', 'api::workshop.workshop'>
-  }
-}
-
-export interface MenuMenuItem extends Schema.Component {
-  collectionName: 'components_menu_menu_items'
-  info: {
-    displayName: 'menu item'
-  }
-  attributes: {
-    label: Attribute.String & Attribute.Required
-    sections: Attribute.Component<'menu.menu-section', true>
-    seeAllLink: Attribute.Component<'items.link'>
-  }
-}
-
 export interface SectionsWorkshops extends Schema.Component {
   collectionName: 'components_sections_workshops'
   info: {
@@ -583,6 +530,59 @@ export interface SectionsArticlesHomepageSection extends Schema.Component {
   }
 }
 
+export interface MenuMenuSection extends Schema.Component {
+  collectionName: 'components_menu_menu_sections'
+  info: {
+    displayName: 'menu section'
+    description: ''
+  }
+  attributes: {
+    label: Attribute.String & Attribute.Required
+    links: Attribute.Component<'menu.menu-link', true>
+    colSpan: Attribute.Integer &
+      Attribute.Required &
+      Attribute.SetMinMax<
+        {
+          min: 0
+          max: 3
+        },
+        number
+      > &
+      Attribute.DefaultTo<1>
+    multicolumnBehaviour: Attribute.Enumeration<['fullwidth', 'split equally']>
+    hasDividers: Attribute.Boolean & Attribute.Required & Attribute.DefaultTo<false>
+    specialSectionType: Attribute.Enumeration<['latest articles']>
+  }
+}
+
+export interface MenuMenuLink extends Schema.Component {
+  collectionName: 'components_menu_menu_link'
+  info: {
+    displayName: 'menu link'
+    description: ''
+  }
+  attributes: {
+    label: Attribute.String
+    url: Attribute.String
+    page: Attribute.Relation<'menu.menu-link', 'oneToOne', 'api::page.page'>
+    branch: Attribute.Relation<'menu.menu-link', 'oneToOne', 'api::branch.branch'>
+    service: Attribute.Relation<'menu.menu-link', 'oneToOne', 'api::service.service'>
+    workshop: Attribute.Relation<'menu.menu-link', 'oneToOne', 'api::workshop.workshop'>
+  }
+}
+
+export interface MenuMenuItem extends Schema.Component {
+  collectionName: 'components_menu_menu_items'
+  info: {
+    displayName: 'menu item'
+  }
+  attributes: {
+    label: Attribute.String & Attribute.Required
+    sections: Attribute.Component<'menu.menu-section', true>
+    seeAllLink: Attribute.Component<'items.link'>
+  }
+}
+
 export interface ItemsWorkshopDate extends Schema.Component {
   collectionName: 'components_items_workshop_dates'
   info: {
@@ -1004,9 +1004,6 @@ export interface HeaderSectionsBranchMap extends Schema.Component {
 declare module '@strapi/types' {
   export module Shared {
     export interface Components {
-      'menu.menu-section': MenuMenuSection
-      'menu.menu-link': MenuMenuLink
-      'menu.menu-item': MenuMenuItem
       'sections.workshops': SectionsWorkshops
       'sections.waste-sorting-cards': SectionsWasteSortingCards
       'sections.vacancies': SectionsVacancies
@@ -1039,6 +1036,9 @@ declare module '@strapi/types' {
       'sections.banner': SectionsBanner
       'sections.articles': SectionsArticles
       'sections.articles-homepage-section': SectionsArticlesHomepageSection
+      'menu.menu-section': MenuMenuSection
+      'menu.menu-link': MenuMenuLink
+      'menu.menu-item': MenuMenuItem
       'items.workshop-date': ItemsWorkshopDate
       'items.waste-sorting-cards-item': ItemsWasteSortingCardsItem
       'items.sorting-guide': ItemsSortingGuide

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -1344,7 +1344,7 @@ export interface ApiOpeningTimeOpeningTime extends Schema.CollectionType {
     draftAndPublish: false
   }
   attributes: {
-    internalName: Attribute.String & Attribute.Required
+    internalName: Attribute.String & Attribute.Private
     branches: Attribute.Relation<
       'api::opening-time.opening-time',
       'manyToMany',


### PR DESCRIPTION
- Set `internalName` on `OpeningTimeEntity` as private (previously required), so that we do not fetch it at front-end