### PR TITLE
Temporarily don't fetch General context

### DIFF
--- a/next/src/pages/articles/[slug].tsx
+++ b/next/src/pages/articles/[slug].tsx
@@ -27,7 +27,7 @@ import { isDefined } from '@/src/utils/isDefined'
 import { generalQuery, latestArticlesQuery } from '@/src/utils/queryOptions'
 
 type PageProps = {
-  general: GeneralQuery
+  general?: GeneralQuery
   navigation: NavigationObject
   entity: ArticleEntityFragment
 }
@@ -68,9 +68,9 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
     return NOT_FOUND
   }
 
-  const [{ articles: entities }, general, navigation, translations] = await Promise.all([
+  const [{ articles: entities }, /* general, */ navigation, translations] = await Promise.all([
     client.ArticleBySlug({ slug, locale }),
-    client.General({ locale }),
+    // client.General({ locale }),
     fetchNavigation(navigationConfig),
     serverSideTranslations(locale),
   ])
@@ -91,7 +91,7 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
   return {
     props: {
       entity,
-      general,
+      // general,
       navigation,
       dehydratedState,
       ...translations,

--- a/next/src/pages/documents/[slug].tsx
+++ b/next/src/pages/documents/[slug].tsx
@@ -22,7 +22,7 @@ import { getPageBreadcrumbs } from '@/src/utils/getPageBreadcrumbs'
 import { generalQuery, latestArticlesQuery } from '@/src/utils/queryOptions'
 
 type PageProps = {
-  general: GeneralQuery
+  general?: GeneralQuery
   navigation: NavigationObject
   entity: DocumentEntityFragment
 }
@@ -51,9 +51,9 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
     return NOT_FOUND
   }
 
-  const [{ documents: entities }, general, navigation, translations] = await Promise.all([
+  const [{ documents: entities }, /* general, */ navigation, translations] = await Promise.all([
     client.DocumentBySlug({ slug }),
-    client.General({ locale }),
+    // client.General({ locale }),
     fetchNavigation(navigationConfig),
     serverSideTranslations(locale),
   ])
@@ -74,7 +74,7 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
   return {
     props: {
       entity,
-      general,
+      // general,
       navigation,
       dehydratedState,
       ...translations,

--- a/next/src/pages/faq-categories/[slug].tsx
+++ b/next/src/pages/faq-categories/[slug].tsx
@@ -23,7 +23,7 @@ import { getPageBreadcrumbs } from '@/src/utils/getPageBreadcrumbs'
 import { generalQuery, latestArticlesQuery } from '@/src/utils/queryOptions'
 
 type PageProps = {
-  general: GeneralQuery
+  general?: GeneralQuery
   navigation: NavigationObject
   entity: FaqCategoryEntityFragment
 }
@@ -52,9 +52,9 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
     return NOT_FOUND
   }
 
-  const [{ faqCategories: entities }, general, navigation, translations] = await Promise.all([
+  const [{ faqCategories: entities }, /* general, */ navigation, translations] = await Promise.all([
     client.FaqCategoryBySlug({ slug, locale }),
-    client.General({ locale }),
+    // client.General({ locale }),
     fetchNavigation(navigationConfig),
     serverSideTranslations(locale),
   ])
@@ -75,7 +75,7 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
   return {
     props: {
       entity,
-      general,
+      // general,
       navigation,
       dehydratedState,
       ...translations,

--- a/next/src/pages/services/[slug].tsx
+++ b/next/src/pages/services/[slug].tsx
@@ -22,7 +22,7 @@ import { getPageBreadcrumbs } from '@/src/utils/getPageBreadcrumbs'
 import { generalQuery, latestArticlesQuery } from '@/src/utils/queryOptions'
 
 type PageProps = {
-  general: GeneralQuery
+  general?: GeneralQuery
   navigation: NavigationObject
   entity: ServiceEntityFragment
 }
@@ -63,9 +63,9 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
     return NOT_FOUND
   }
 
-  const [{ services: entities }, general, navigation, translations] = await Promise.all([
+  const [{ services: entities }, /* general, */ navigation, translations] = await Promise.all([
     client.ServiceBySlug({ slug, locale }),
-    client.General({ locale }),
+    // client.General({ locale }),
     fetchNavigation(navigationConfig),
     serverSideTranslations(locale),
   ])
@@ -86,7 +86,7 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
   return {
     props: {
       entity,
-      general,
+      // general,
       navigation,
       dehydratedState,
       ...translations,

--- a/next/src/pages/workshops/[slug].tsx
+++ b/next/src/pages/workshops/[slug].tsx
@@ -23,7 +23,7 @@ import { isDefined } from '@/src/utils/isDefined'
 import { generalQuery, latestArticlesQuery } from '@/src/utils/queryOptions'
 
 type PageProps = {
-  general: GeneralQuery
+  general?: GeneralQuery
   navigation: NavigationObject
   entity: WorkshopEntityFragment
 }
@@ -64,9 +64,9 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
     return NOT_FOUND
   }
 
-  const [{ workshops: entities }, general, navigation, translations] = await Promise.all([
+  const [{ workshops: entities }, /* general, */ navigation, translations] = await Promise.all([
     client.WorkshopBySlug({ slug }),
-    client.General({ locale }),
+    // client.General({ locale }),
     fetchNavigation(navigationConfig),
     serverSideTranslations(locale),
   ])
@@ -87,7 +87,7 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
   return {
     props: {
       entity,
-      general,
+      // general,
       navigation,
       dehydratedState,
       ...translations,

--- a/next/src/providers/GeneralContextProvider.tsx
+++ b/next/src/providers/GeneralContextProvider.tsx
@@ -16,7 +16,7 @@ const GeneralContext = createContext<GeneralContextType | null>(null)
 // contentTypePathPrefixesMap is used to get path of Content Type's parent page, e.g. path prefix for Articles or Documents etc.
 type GeneralContextProviderProps = {
   children: ReactNode
-  general: GeneralQuery
+  general: GeneralQuery | null | undefined
   navigation: NavigationObject
 }
 

--- a/next/src/services/meili/meiliClient.ts
+++ b/next/src/services/meili/meiliClient.ts
@@ -3,11 +3,11 @@ import { MeiliSearch } from 'meilisearch'
 export const MEILI_PAGE_SIZE = 10
 
 // eslint-disable-next-line no-console
-console.log(
-  'NEXT_PUBLIC_MEILISEARCH_HOST:',
-  process.env.NEXT_PUBLIC_MEILISEARCH_HOST,
-  process.env.NEXT_PUBLIC_MEILISEARCH_SEARCH_API_KEY,
-)
+// console.log(
+//   'NEXT_PUBLIC_MEILISEARCH_HOST:',
+//   process.env.NEXT_PUBLIC_MEILISEARCH_HOST,
+//   process.env.NEXT_PUBLIC_MEILISEARCH_SEARCH_API_KEY,
+// )
 
 export const meiliClient = new MeiliSearch({
   host: process.env.NEXT_PUBLIC_MEILISEARCH_HOST ?? '',


### PR DESCRIPTION
We now fetch these data client-side and we prefetch them. Keeping General Context in code for future use.