### PR TITLE
#513 Fix image overlap with z-index

### DIFF
--- a/next/src/components/sections/headers/PageHeaderSideImage.stories.tsx
+++ b/next/src/components/sections/headers/PageHeaderSideImage.stories.tsx
@@ -3,20 +3,23 @@ import type { Meta, StoryObj } from '@storybook/react'
 import imagePlaceholder from '@/src/assets/images/olo-truck.jpg'
 import { SideImageHeaderSectionFragment } from '@/src/services/graphql/api'
 
-import PageHeaderSideImageComponent from './PageHeaderSideImage'
+import PageHeaderSideImageComponent, { PageHeaderSideImageProps } from './PageHeaderSideImage'
 
 type Props = SideImageHeaderSectionFragment & {
-  title: string
-  perex?: string
   imageUrl: string
-}
+} & Pick<PageHeaderSideImageProps, 'breadcrumbs' | 'title' | 'perex'>
 
 const meta: Meta<Props> = {
   title: 'Page Headers/Obrázok vpravo',
   args: {
-    title: 'KOLO – Bratislavské centrum opätovného použitia',
-    perex: '',
+    title: 'KOLO Karlovka',
+    perex:
+      'Lorem ipsum dolor sit amet consectetur. Nisi non integer fringilla vel arcu vitae iaculis lorem. Semper at vestibulum massa ut nulla quisque tortor a aliquam. Enim vitae rhoncus sed dictum viverra pellentesque tincidunt convallis nulla. Aliquam diam ultrices aliquam diam venenatis.',
     imageUrl: imagePlaceholder.src,
+    breadcrumbs: [
+      { title: 'KOLO - Bratislavské centrum opätovného použitia', path: '#' },
+      { title: 'KOLO Karlovka', path: '#' },
+    ],
   },
 }
 
@@ -34,9 +37,7 @@ export const PageHeaderSideImage: Story = {
           },
         },
       }}
-      title={args.title}
-      perex={args.perex}
-      breadcrumbs={[]}
+      {...args}
     />
   ),
 }

--- a/next/src/components/sections/headers/PageHeaderSideImage.tsx
+++ b/next/src/components/sections/headers/PageHeaderSideImage.tsx
@@ -31,7 +31,7 @@ const PageHeaderSideImage = ({ title, perex, header, breadcrumbs }: PageHeaderSi
         <SectionContainer background="secondary">
           <div className="grid grid-cols-2 gap-12">
             {/* Using a high z-index ensures users can click the breadcrumbs */}
-            <div className="z-50">
+            <div className="z-10">
               <Breadcrumbs breadcrumbs={breadcrumbs} />
               <HeaderTitleText title={title} text={perex} className="col-[1] grow lg:py-24" />
             </div>

--- a/next/src/components/sections/headers/PageHeaderSideImage.tsx
+++ b/next/src/components/sections/headers/PageHeaderSideImage.tsx
@@ -7,7 +7,7 @@ import HeaderTitleText from '@/src/components/sections/headers/HeaderTitleText'
 import { SideImageHeaderSectionFragment } from '@/src/services/graphql/api'
 import { Breadcrumb } from '@/src/utils/getPageBreadcrumbs'
 
-type Props = {
+export type PageHeaderSideImageProps = {
   title: string
   perex?: string | null | undefined
   header: SideImageHeaderSectionFragment
@@ -18,7 +18,7 @@ type Props = {
  * Figma: https://www.figma.com/design/2qF09hDT9QNcpdztVMNAY4/OLO-Web?node-id=1192-12977&m=dev
  */
 
-const PageHeaderSideImage = ({ title, perex, header, breadcrumbs }: Props) => {
+const PageHeaderSideImage = ({ title, perex, header, breadcrumbs }: PageHeaderSideImageProps) => {
   const { media } = header
 
   const { url: imageUrl } = media.data?.attributes ?? {}
@@ -30,7 +30,8 @@ const PageHeaderSideImage = ({ title, perex, header, breadcrumbs }: Props) => {
         {/* This container ensures that the text part of header scales correctly with window width  */}
         <SectionContainer background="secondary">
           <div className="grid grid-cols-2 gap-12">
-            <div>
+            {/* Using a high z-index ensures users can click the breadcrumbs */}
+            <div className="z-50">
               <Breadcrumbs breadcrumbs={breadcrumbs} />
               <HeaderTitleText title={title} text={perex} className="col-[1] grow lg:py-24" />
             </div>
@@ -38,7 +39,7 @@ const PageHeaderSideImage = ({ title, perex, header, breadcrumbs }: Props) => {
         </SectionContainer>
         {/* This div serves as an empty space for the image to overlap correctly */}
         <div aria-hidden className="h-18" />
-        {/* This div overlaps the grid in SectionContainer and and allows the image to fill the whole right side */}
+        {/* This div overlaps the grid in SectionContainer and allows the image to fill the whole right side */}
         <div className="absolute top-0 grid size-full grid-cols-2 gap-12">
           <div className="relative col-[2] size-full overflow-hidden rounded-bl-2xl">
             {imageUrl ? (


### PR DESCRIPTION
- Add `z-50` to the div wrapping `Breadcrumbs` component

![link-accessible](https://github.com/user-attachments/assets/f79cda5e-85c8-4e50-a03d-5f99d4e827cb)
