### PR TITLE
#386 Create header for Careers page

### DIFF
--- a/next/public/locales/sk/translation.json
+++ b/next/public/locales/sk/translation.json
@@ -57,6 +57,7 @@
   "navBar.branchCard.showDetails": "Zobraziť detaily",
   "navBar.contactsButton": "Kontakty",
   "navBar.workshopCard.messageMostRecentDate": "Najbližší termín: {{mostRecentWorkshopDate}}",
+  "pageHeaderCareers.aria.videoTitle": "Videopríbeh o pracovných príležitostiach a firemných hodnotách spoločnosti OLO",
   "pageHeaderGallery.buttonText": "Všetky fotky",
   "pageHeaderPickupDay.allNews": "Všetky novinky",
   "pageHeaderPickupDay.messageEvenWeek": "Tento týždeň je párny ({{weekNumber}}. týždeň)",

--- a/next/src/components/common/Image/ImageAndTextOverlapped.stories.tsx
+++ b/next/src/components/common/Image/ImageAndTextOverlapped.stories.tsx
@@ -1,0 +1,44 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Meta, StoryObj } from '@storybook/react'
+
+import { OloTruckImage } from '@/src/assets/images'
+import { ImageAndTextOverlappedProps } from '@/src/components/common/Image/ImageAndTextOverlapped'
+import {
+  Enum_Componentsectionsimageandtextoverlapped_Backgroundcolor as Enum_Backgroundcolor,
+  Enum_Componentsectionsimageandtextoverlapped_Imageposition as Enum_Imageposition,
+} from '@/src/services/graphql/api'
+
+import ImageAndTextOverlappedComponent from './ImageAndTextOverlapped'
+
+type Props = ImageAndTextOverlappedProps
+
+const meta: Meta<Props> = {
+  // eslint-disable-next-line no-secrets/no-secrets
+  title: 'Components/Image',
+  component: ImageAndTextOverlappedComponent,
+  tags: ['autodocs'],
+  args: {
+    title:
+      'Zhodnocovaním odpadu robíme radosť deťom, z ktorých sme vyrástli, aj ďalším generáciám.',
+    imagePosition: Enum_Imageposition.Left,
+    backgroundColor: Enum_Backgroundcolor.Secondary,
+    image: {
+      data: {
+        attributes: {
+          url: OloTruckImage.src,
+        },
+      },
+    },
+  },
+  parameters: {
+    controls: { exclude: ['image', 'text', 'readMoreLink'] },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<Props>
+
+export const ImageAndTextOverlapped: Story = {
+  render: (args) => <ImageAndTextOverlappedComponent {...args} />,
+}

--- a/next/src/components/common/Image/ImageAndTextOverlapped.tsx
+++ b/next/src/components/common/Image/ImageAndTextOverlapped.tsx
@@ -1,0 +1,156 @@
+import Image from 'next/image'
+import React from 'react'
+
+import ImagePlaceholder from '@/src/components/common/ImagePlaceholder'
+import SectionHeader from '@/src/components/layout/Section/SectionHeader'
+import {
+  Enum_Componentsectionsimageandtextoverlapped_Backgroundcolor as Enum_Backgroundcolor,
+  Enum_Componentsectionsimageandtextoverlapped_Imageposition as Enum_Imageposition,
+  LinkFragment,
+} from '@/src/services/graphql/api'
+import cn from '@/src/utils/cn'
+import { generateImageSizes } from '@/src/utils/generateImageSizes'
+import { useGetLinkProps } from '@/src/utils/useGetLinkProps'
+
+import Button from '../Button/Button'
+
+export type ImageAndTextOverlappedProps = {
+  title?: string | null
+  text?: string | null
+  imagePosition: Enum_Imageposition
+  backgroundColor: Enum_Backgroundcolor
+  image?: any // TODO: Resolve the type for the image
+  readMoreLink?: LinkFragment | null
+}
+
+/**
+ * Figma: https://www.figma.com/design/2qF09hDT9QNcpdztVMNAY4/OLO-Web?node-id=1199-14543&m=dev
+ */
+
+const ImageAndTextOverlapped = ({
+  title,
+  text,
+  imagePosition,
+  backgroundColor,
+  image,
+  readMoreLink,
+}: ImageAndTextOverlappedProps) => {
+  const { getLinkProps } = useGetLinkProps()
+
+  const isImageShifted =
+    imagePosition === Enum_Imageposition.LeftShifted ||
+    imagePosition === Enum_Imageposition.RightShifted
+
+  const isImageLeft =
+    imagePosition === Enum_Imageposition.Left || imagePosition === Enum_Imageposition.LeftShifted
+  const isImageRight =
+    imagePosition === Enum_Imageposition.Right || imagePosition === Enum_Imageposition.RightShifted
+
+  const TextContent = (
+    <div className="flex flex-col gap-6">
+      <SectionHeader title={title} text={text} />
+      {readMoreLink ? (
+        <Button variant="black-link" asLink hasLinkIcon {...getLinkProps(readMoreLink)} />
+      ) : null}
+    </div>
+  )
+
+  const DesktopTextContainer = (
+    <div
+      className={cn(
+        'z-1 flex grow flex-col gap-6 self-start rounded-lg p-6 lg:rounded-2xl lg:p-18',
+        {
+          'bg-background-primary': backgroundColor !== Enum_Backgroundcolor.Primary,
+          'bg-background-tertiary': backgroundColor === Enum_Backgroundcolor.Primary,
+          'lg:-ml-9': isImageLeft,
+          'lg:-mr-9': isImageRight,
+          'my-18': !isImageShifted,
+          'mt-18': isImageShifted,
+        },
+      )}
+    >
+      {TextContent}
+    </div>
+  )
+
+  const MobileTextContainer = (
+    <div
+      className={cn('z-1 flex w-full grow flex-col gap-6 self-start rounded-lg p-6', {
+        'bg-background-primary': backgroundColor !== Enum_Backgroundcolor.Primary,
+        'bg-background-tertiary': backgroundColor === Enum_Backgroundcolor.Primary,
+        '-mt-6': isImageLeft,
+        '-mb-6': isImageRight,
+      })}
+    >
+      {TextContent}
+    </div>
+  )
+
+  const ImageContent = image?.data?.attributes?.url ? (
+    <Image
+      src={image.data.attributes.url}
+      alt={image.data.attributes.alternativeText ?? ''}
+      fill
+      sizes={generateImageSizes({ md: '50vw', default: '100vw' })}
+      className="object-cover"
+    />
+  ) : (
+    <ImagePlaceholder />
+  )
+
+  const DesktopImageContainer = (
+    <div
+      className={cn('relative shrink-0 overflow-hidden rounded-3xl', {
+        'lg:-mr-9': isImageLeft,
+        'lg:-ml-9': isImageRight,
+        'mb-18': isImageShifted,
+      })}
+    >
+      {ImageContent}
+    </div>
+  )
+
+  const MobileImageContainer = (
+    <div
+      className={cn('relative -mx-4 aspect-[320/246]', {
+        '-mt-6': isImageLeft,
+        '-mb-6': isImageRight,
+      })}
+    >
+      {ImageContent}
+    </div>
+  )
+
+  return (
+    <div>
+      <div className="hidden lg:grid lg:grid-cols-2">
+        {isImageLeft ? (
+          <>
+            {DesktopImageContainer}
+            {DesktopTextContainer}
+          </>
+        ) : (
+          <>
+            {DesktopTextContainer}
+            {DesktopImageContainer}
+          </>
+        )}
+      </div>
+      <div className="flex flex-col justify-center lg:hidden">
+        {isImageLeft ? (
+          <>
+            {MobileImageContainer}
+            {MobileTextContainer}
+          </>
+        ) : (
+          <>
+            {MobileTextContainer}
+            {MobileImageContainer}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default ImageAndTextOverlapped

--- a/next/src/components/common/Video/Video.stories.tsx
+++ b/next/src/components/common/Video/Video.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import VideoComponent, { VideoProps } from './Video'
+
+type Props = VideoProps
+
+const meta: Meta<Props> = {
+  title: 'Components/Video',
+  tags: ['autodocs'],
+  args: {
+    url: 'https://www.youtube.com/embed/8QBjTTCj2JA',
+    ariaLabel: 'Videopríbeh o pracovných príležitostiach a firemných hodnotách spoločnosti OLO',
+  },
+}
+
+type Story = StoryObj<Props>
+
+export const Video: Story = {
+  render: (args) => (
+    <div className="h-[42.75rem] max-w-[76rem]">
+      <VideoComponent {...args} />
+    </div>
+  ),
+}
+
+export default meta

--- a/next/src/components/common/Video/Video.tsx
+++ b/next/src/components/common/Video/Video.tsx
@@ -1,0 +1,24 @@
+export type VideoProps = {
+  url: string
+  ariaLabel: string
+}
+
+/**
+ * Figma: https://www.figma.com/file/2qF09hDT9QNcpdztVMNAY4/OLO-Web?node-id=1199%3A13348
+ */
+
+const Video = ({ url, ariaLabel }: VideoProps) => {
+  return (
+    <div className="size-full overflow-hidden rounded-3xl">
+      <iframe
+        width="100%"
+        height="100%"
+        title={ariaLabel}
+        src={url}
+        allow="accelerometer; encrypted-media; gyroscope; web-share"
+      />
+    </div>
+  )
+}
+
+export default Video

--- a/next/src/components/common/Video/Video.tsx
+++ b/next/src/components/common/Video/Video.tsx
@@ -7,9 +7,11 @@ export type VideoProps = {
  * Figma: https://www.figma.com/file/2qF09hDT9QNcpdztVMNAY4/OLO-Web?node-id=1199%3A13348
  */
 
+// TODO: The video should scale responsively
+
 const Video = ({ url, ariaLabel }: VideoProps) => {
   return (
-    <div className="size-full overflow-hidden rounded-3xl">
+    <div className="h-[10.125rem] overflow-hidden rounded-3xl lg:h-[42.75rem]">
       <iframe
         width="100%"
         height="100%"

--- a/next/src/components/sections/ImageAndTextOverlappedSection.tsx
+++ b/next/src/components/sections/ImageAndTextOverlappedSection.tsx
@@ -1,18 +1,8 @@
-import Image from 'next/image'
 import React from 'react'
 
-import Button from '@/src/components/common/Button/Button'
-import ImagePlaceholder from '@/src/components/common/ImagePlaceholder'
+import ImageAndTextOverlapped from '@/src/components/common/Image/ImageAndTextOverlapped'
 import SectionContainer from '@/src/components/layout/Section/SectionContainer'
-import SectionHeader from '@/src/components/layout/Section/SectionHeader'
-import {
-  Enum_Componentsectionsimageandtextoverlapped_Backgroundcolor as Enum_Backgroundcolor,
-  Enum_Componentsectionsimageandtextoverlapped_Imageposition as Enum_Imageposition,
-  ImageAndTextOverlappedSectionFragment,
-} from '@/src/services/graphql/api'
-import cn from '@/src/utils/cn'
-import { generateImageSizes } from '@/src/utils/generateImageSizes'
-import { useGetLinkProps } from '@/src/utils/useGetLinkProps'
+import { ImageAndTextOverlappedSectionFragment } from '@/src/services/graphql/api'
 
 type Props = {
   section: ImageAndTextOverlappedSectionFragment
@@ -32,121 +22,17 @@ const ImageAndTextOverlappedSection = ({ section }: Props) => {
     readMoreLink,
   } = section
 
-  const { getLinkProps } = useGetLinkProps()
-
-  const isImageShifted =
-    imagePosition === Enum_Imageposition.LeftShifted ||
-    imagePosition === Enum_Imageposition.RightShifted
-
-  const isImageLeft =
-    imagePosition === Enum_Imageposition.Left || imagePosition === Enum_Imageposition.LeftShifted
-  const isImageRight =
-    imagePosition === Enum_Imageposition.Right || imagePosition === Enum_Imageposition.RightShifted
-
-  const TextContent = (
-    <div className="flex flex-col gap-6">
-      <SectionHeader title={title} text={text} />
-      {readMoreLink ? (
-        <Button variant="black-link" asLink hasLinkIcon {...getLinkProps(readMoreLink)} />
-      ) : null}
-    </div>
-  )
-
-  const DesktopTextContainer = (
-    <div
-      className={cn(
-        'z-1 flex grow flex-col gap-6 self-start rounded-lg p-6 lg:rounded-2xl lg:p-18',
-        {
-          'bg-background-primary': backgroundColor !== Enum_Backgroundcolor.Primary,
-          'bg-background-tertiary': backgroundColor === Enum_Backgroundcolor.Primary,
-          'lg:-ml-9': isImageLeft,
-          'lg:-mr-9': isImageRight,
-          'my-18': !isImageShifted,
-          'mt-18': isImageShifted,
-        },
-      )}
-    >
-      {TextContent}
-    </div>
-  )
-
-  const MobileTextContainer = (
-    <div
-      className={cn('z-1 flex w-full grow flex-col gap-6 self-start rounded-lg p-6', {
-        'bg-background-primary': backgroundColor !== Enum_Backgroundcolor.Primary,
-        'bg-background-tertiary': backgroundColor === Enum_Backgroundcolor.Primary,
-        '-mt-6': isImageLeft,
-        '-mb-6': isImageRight,
-      })}
-    >
-      {TextContent}
-    </div>
-  )
-
-  const ImageContent = image.data?.attributes?.url ? (
-    <Image
-      src={image.data.attributes.url}
-      alt={image.data.attributes.alternativeText ?? ''}
-      fill
-      sizes={generateImageSizes({ md: '50vw', default: '100vw' })}
-      className="object-cover"
-    />
-  ) : (
-    <ImagePlaceholder />
-  )
-
-  const DesktopImageContainer = (
-    <div
-      className={cn('relative shrink-0 overflow-hidden rounded-3xl', {
-        'lg:-mr-9': isImageLeft,
-        'lg:-ml-9': isImageRight,
-        'mb-18': isImageShifted,
-      })}
-    >
-      {ImageContent}
-    </div>
-  )
-
-  const MobileImageContainer = (
-    <div
-      className={cn('relative -mx-4 aspect-[320/246]', {
-        '-mt-6': isImageLeft,
-        '-mb-6': isImageRight,
-      })}
-    >
-      {ImageContent}
-    </div>
-  )
-
   return (
     // TODO padding-y should probably be managed by the SectionContainer
     <SectionContainer background={backgroundColor} className="py-6 lg:py-12">
-      <div className="hidden lg:grid lg:grid-cols-2">
-        {isImageLeft ? (
-          <>
-            {DesktopImageContainer}
-            {DesktopTextContainer}
-          </>
-        ) : (
-          <>
-            {DesktopTextContainer}
-            {DesktopImageContainer}
-          </>
-        )}
-      </div>
-      <div className="flex flex-col lg:hidden">
-        {isImageLeft ? (
-          <>
-            {MobileImageContainer}
-            {MobileTextContainer}
-          </>
-        ) : (
-          <>
-            {MobileTextContainer}
-            {MobileImageContainer}
-          </>
-        )}
-      </div>
+      <ImageAndTextOverlapped
+        title={title}
+        text={text}
+        imagePosition={imagePosition}
+        backgroundColor={backgroundColor}
+        image={image}
+        readMoreLink={readMoreLink}
+      />
     </SectionContainer>
   )
 }

--- a/next/src/components/sections/headers/CareersPageHeader.stories.tsx
+++ b/next/src/components/sections/headers/CareersPageHeader.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { OloTruckImage } from '@/src/assets/images'
+import { CareersHeaderSectionFragment } from '@/src/services/graphql/api'
+
+import CareersPageHeaderComponent from './CareersPageHeader'
+
+type Props = CareersHeaderSectionFragment
+
+const meta: Meta<Props> = {
+  title: 'Page Headers/Kariéra',
+  args: {
+    title: 'Kariéra v OLO',
+    text: 'Dobre fungujúce mesto sa nezaobíde bez odvozu a zhodnocovania odpadu. OLO sa zasa nezaobíde bez spoľahlivých ľudí. Za vašu prácu vám ponúkame zázemie stabilnej a perspektívnej spoločnosti, ktorá si svojich zamestnancov a zamestnankyne váži a vie ich patrične oceniť. Viete, čo je dôkazom, že sme v OLO spokojní? Viac ako polovica zamestnancov je s nami vyše desať rokov!',
+    videoUrl: 'https://www.youtube.com/embed/8QBjTTCj2JA',
+    imageWithText: {
+      title:
+        'Zhodnocovaním odpadu robíme radosť deťom, z ktorých sme vyrástli, aj ďalším generáciám.',
+      image: {
+        data: {
+          attributes: {
+            url: OloTruckImage.src,
+          },
+        },
+      },
+    },
+  },
+}
+
+type Story = StoryObj<Props>
+
+export const CareersPageHeader: Story = {
+  name: 'Kariéra',
+  render: (args: Props) => <CareersPageHeaderComponent section={{ ...args }} />,
+}
+
+export default meta

--- a/next/src/components/sections/headers/CareersPageHeader.tsx
+++ b/next/src/components/sections/headers/CareersPageHeader.tsx
@@ -1,0 +1,49 @@
+import { useTranslation } from 'next-i18next'
+
+import ImageAndTextOverlapped from '@/src/components/common/Image/ImageAndTextOverlapped'
+import Typography from '@/src/components/common/Typography/Typography'
+import Video from '@/src/components/common/Video/Video'
+import SectionContainer from '@/src/components/layout/Section/SectionContainer'
+import {
+  CareersHeaderSectionFragment,
+  Enum_Componentsectionsimageandtextoverlapped_Backgroundcolor as Enum_Backgroundcolor,
+  Enum_Componentsectionsimageandtextoverlapped_Imageposition as Enum_Imageposition,
+} from '@/src/services/graphql/api'
+
+type CareersPageHeaderProps = {
+  section: CareersHeaderSectionFragment
+}
+
+/**
+ * Figma: https://www.figma.com/design/2qF09hDT9QNcpdztVMNAY4/OLO-Web?node-id=952-7340&t=G8gUCwznUtpSprDI-1
+ */
+
+const CareersPageHeader = ({ section }: CareersPageHeaderProps) => {
+  const { t } = useTranslation()
+  const { title: sectionTitle, text, videoUrl, imageWithText } = section ?? {}
+  const { title, image } = imageWithText ?? {}
+
+  return (
+    <SectionContainer background="secondary" classNameInner="py-6 lg:pb-[4.5rem] lg:pt-12">
+      <div className="flex flex-col gap-6 lg:gap-12">
+        <div className="flex flex-col gap-4 pb-6 lg:gap-6 lg:py-0">
+          <Typography variant="h1">{sectionTitle ?? ''}</Typography>
+          <Typography variant="p-default">{text ?? ''}</Typography>
+        </div>
+
+        <div className="flex flex-col gap-6 lg:gap-18">
+          <ImageAndTextOverlapped
+            title={title}
+            imagePosition={Enum_Imageposition.Left}
+            backgroundColor={Enum_Backgroundcolor.Secondary} // White background
+            image={image}
+          />
+
+          <Video url={videoUrl} ariaLabel={t('pageHeaderCareers.aria.videoTitle')} />
+        </div>
+      </div>
+    </SectionContainer>
+  )
+}
+
+export default CareersPageHeader

--- a/next/src/services/graphql/api.ts
+++ b/next/src/services/graphql/api.ts
@@ -332,6 +332,15 @@ export type ComponentHeaderSectionsBranchMapBranchesArgs = {
   sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
 }
 
+export type ComponentHeaderSectionsCareers = {
+  __typename?: 'ComponentHeaderSectionsCareers'
+  id: Scalars['ID']['output']
+  imageWithText?: Maybe<ComponentItemsImageAndTextOverlappedItem>
+  text?: Maybe<Scalars['String']['output']>
+  title?: Maybe<Scalars['String']['output']>
+  videoUrl: Scalars['String']['output']
+}
+
 export type ComponentHeaderSectionsFeaturedNews = {
   __typename?: 'ComponentHeaderSectionsFeaturedNews'
   articlesTitle: Scalars['String']['output']
@@ -604,6 +613,13 @@ export type ComponentItemsHomepageServiceTileInput = {
   link?: InputMaybe<ComponentItemsLinkInput>
   text?: InputMaybe<Scalars['String']['input']>
   title?: InputMaybe<Scalars['String']['input']>
+}
+
+export type ComponentItemsImageAndTextOverlappedItem = {
+  __typename?: 'ComponentItemsImageAndTextOverlappedItem'
+  id: Scalars['ID']['output']
+  image?: Maybe<UploadFileEntityResponse>
+  text?: Maybe<Scalars['String']['output']>
 }
 
 export type ComponentItemsLink = {
@@ -2033,6 +2049,7 @@ export type GenericMorph =
   | ArticleCategory
   | Branch
   | ComponentHeaderSectionsBranchMap
+  | ComponentHeaderSectionsCareers
   | ComponentHeaderSectionsFeaturedNews
   | ComponentHeaderSectionsGallery
   | ComponentHeaderSectionsIcon
@@ -2050,6 +2067,7 @@ export type GenericMorph =
   | ComponentItemsHeroMainTile
   | ComponentItemsHeroSmallTile
   | ComponentItemsHomepageServiceTile
+  | ComponentItemsImageAndTextOverlappedItem
   | ComponentItemsLink
   | ComponentItemsMenuHeader
   | ComponentItemsOpeningHoursItem
@@ -4937,6 +4955,19 @@ export type FileItemFragment = {
   }
 }
 
+export type ImageAndTextOverlappedItemFragment = {
+  __typename?: 'ComponentItemsImageAndTextOverlappedItem'
+  text?: string | null
+  image?: {
+    __typename?: 'UploadFileEntityResponse'
+    data?: {
+      __typename?: 'UploadFileEntity'
+      id?: string | null
+      attributes?: { __typename?: 'UploadFile'; url: string } | null
+    } | null
+  } | null
+}
+
 export type NavigationEntityFragment = {
   __typename?: 'NavigationEntity'
   attributes?: {
@@ -5666,6 +5697,25 @@ export type GalleryHeaderSectionFragment = {
       } | null
     }>
   }
+}
+
+export type CareersHeaderSectionFragment = {
+  __typename?: 'ComponentHeaderSectionsCareers'
+  title?: string | null
+  text?: string | null
+  videoUrl: string
+  imageWithText?: {
+    __typename?: 'ComponentItemsImageAndTextOverlappedItem'
+    text?: string | null
+    image?: {
+      __typename?: 'UploadFileEntityResponse'
+      data?: {
+        __typename?: 'UploadFileEntity'
+        id?: string | null
+        attributes?: { __typename?: 'UploadFile'; url: string } | null
+      } | null
+    } | null
+  } | null
 }
 
 export type FeaturedNewsHeaderSectionFragment = {
@@ -26162,14 +26212,6 @@ export type WorkshopBySlugQuery = {
   } | null
 }
 
-export const UploadImageSrcEntityFragmentDoc = gql`
-  fragment UploadImageSrcEntity on UploadFileEntity {
-    id
-    attributes {
-      url
-    }
-  }
-`
 export const PageSlugEntityFragmentDoc = gql`
   fragment PageSlugEntity on PageEntity {
     __typename
@@ -26211,6 +26253,36 @@ export const NavigationEntityFragmentDoc = gql`
     }
   }
   ${PageSlugEntityFragmentDoc}
+`
+export const UploadImageSrcEntityFragmentDoc = gql`
+  fragment UploadImageSrcEntity on UploadFileEntity {
+    id
+    attributes {
+      url
+    }
+  }
+`
+export const ImageAndTextOverlappedItemFragmentDoc = gql`
+  fragment ImageAndTextOverlappedItem on ComponentItemsImageAndTextOverlappedItem {
+    image {
+      data {
+        ...UploadImageSrcEntity
+      }
+    }
+    text
+  }
+  ${UploadImageSrcEntityFragmentDoc}
+`
+export const CareersHeaderSectionFragmentDoc = gql`
+  fragment CareersHeaderSection on ComponentHeaderSectionsCareers {
+    title
+    text
+    videoUrl
+    imageWithText {
+      ...ImageAndTextOverlappedItem
+    }
+  }
+  ${ImageAndTextOverlappedItemFragmentDoc}
 `
 export const IconHeaderSectionFragmentDoc = gql`
   fragment IconHeaderSection on ComponentHeaderSectionsIcon {

--- a/next/src/services/graphql/api.ts
+++ b/next/src/services/graphql/api.ts
@@ -619,7 +619,7 @@ export type ComponentItemsImageAndTextOverlappedItem = {
   __typename?: 'ComponentItemsImageAndTextOverlappedItem'
   id: Scalars['ID']['output']
   image?: Maybe<UploadFileEntityResponse>
-  text?: Maybe<Scalars['String']['output']>
+  title?: Maybe<Scalars['String']['output']>
 }
 
 export type ComponentItemsLink = {
@@ -4957,7 +4957,7 @@ export type FileItemFragment = {
 
 export type ImageAndTextOverlappedItemFragment = {
   __typename?: 'ComponentItemsImageAndTextOverlappedItem'
-  text?: string | null
+  title?: string | null
   image?: {
     __typename?: 'UploadFileEntityResponse'
     data?: {
@@ -5706,7 +5706,7 @@ export type CareersHeaderSectionFragment = {
   videoUrl: string
   imageWithText?: {
     __typename?: 'ComponentItemsImageAndTextOverlappedItem'
-    text?: string | null
+    title?: string | null
     image?: {
       __typename?: 'UploadFileEntityResponse'
       data?: {
@@ -26269,7 +26269,7 @@ export const ImageAndTextOverlappedItemFragmentDoc = gql`
         ...UploadImageSrcEntity
       }
     }
-    text
+    title
   }
   ${UploadImageSrcEntityFragmentDoc}
 `

--- a/next/src/services/graphql/queries/_common.gql
+++ b/next/src/services/graphql/queries/_common.gql
@@ -84,5 +84,5 @@ fragment ImageAndTextOverlappedItem on ComponentItemsImageAndTextOverlappedItem 
       ...UploadImageSrcEntity
     }
   }
-  text
+  title
 }

--- a/next/src/services/graphql/queries/_common.gql
+++ b/next/src/services/graphql/queries/_common.gql
@@ -77,3 +77,12 @@ fragment FileItem on ComponentItemsFileItem {
     }
   }
 }
+
+fragment ImageAndTextOverlappedItem on ComponentItemsImageAndTextOverlappedItem {
+  image {
+    data {
+      ...UploadImageSrcEntity
+    }
+  }
+  text
+}

--- a/next/src/services/graphql/queries/_header-sections.gql
+++ b/next/src/services/graphql/queries/_header-sections.gql
@@ -22,6 +22,15 @@ fragment GalleryHeaderSection on ComponentHeaderSectionsGallery {
   }
 }
 
+fragment CareersHeaderSection on ComponentHeaderSectionsCareers {
+  title
+  text
+  videoUrl
+  imageWithText {
+    ...ImageAndTextOverlappedItem
+  }
+}
+
 fragment FeaturedNewsHeaderSection on ComponentHeaderSectionsFeaturedNews {
   articlesTitle
   firstArticle {

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -240,6 +240,32 @@ input ComponentHeaderSectionsBranchMapInput {
   id: ID
 }
 
+type ComponentHeaderSectionsCareers {
+  id: ID!
+  imageWithText: ComponentItemsImageAndTextOverlappedItem
+  text: String
+  title: String
+  videoUrl: String!
+}
+
+input ComponentHeaderSectionsCareersFiltersInput {
+  and: [ComponentHeaderSectionsCareersFiltersInput]
+  imageWithText: ComponentItemsImageAndTextOverlappedItemFiltersInput
+  not: ComponentHeaderSectionsCareersFiltersInput
+  or: [ComponentHeaderSectionsCareersFiltersInput]
+  text: StringFilterInput
+  title: StringFilterInput
+  videoUrl: StringFilterInput
+}
+
+input ComponentHeaderSectionsCareersInput {
+  id: ID
+  imageWithText: ComponentItemsImageAndTextOverlappedItemInput
+  text: String
+  title: String
+  videoUrl: String
+}
+
 type ComponentHeaderSectionsFeaturedNews {
   articlesTitle: String!
   firstArticle: ArticleEntityResponse
@@ -582,6 +608,25 @@ input ComponentItemsHomepageServiceTileInput {
   link: ComponentItemsLinkInput
   text: String
   title: String
+}
+
+type ComponentItemsImageAndTextOverlappedItem {
+  id: ID!
+  image: UploadFileEntityResponse
+  text: String
+}
+
+input ComponentItemsImageAndTextOverlappedItemFiltersInput {
+  and: [ComponentItemsImageAndTextOverlappedItemFiltersInput]
+  not: ComponentItemsImageAndTextOverlappedItemFiltersInput
+  or: [ComponentItemsImageAndTextOverlappedItemFiltersInput]
+  text: StringFilterInput
+}
+
+input ComponentItemsImageAndTextOverlappedItemInput {
+  id: ID
+  image: ID
+  text: String
 }
 
 type ComponentItemsLink {
@@ -2309,7 +2354,7 @@ type FooterRelationResponseCollection {
   data: [FooterEntity!]!
 }
 
-union GenericMorph = Article | ArticleCategory | Branch | ComponentHeaderSectionsBranchMap | ComponentHeaderSectionsFeaturedNews | ComponentHeaderSectionsGallery | ComponentHeaderSectionsIcon | ComponentHeaderSectionsImage | ComponentHeaderSectionsPickupDay | ComponentHeaderSectionsSideImage | ComponentItemsAnchor | ComponentItemsBoardMembersItem | ComponentItemsCardSliderCard | ComponentItemsCardsListItem | ComponentItemsColumnsItem | ComponentItemsColumnsListItem | ComponentItemsFileItem | ComponentItemsFooterColumn | ComponentItemsHeroMainTile | ComponentItemsHeroSmallTile | ComponentItemsHomepageServiceTile | ComponentItemsLink | ComponentItemsMenuHeader | ComponentItemsOpeningHoursItem | ComponentItemsOpeningTimesItem | ComponentItemsOrderedCardsItem | ComponentItemsSlide | ComponentItemsSortingGuide | ComponentItemsSortingGuideAccordionItem | ComponentItemsSortingGuideAlertMessage | ComponentItemsSortingGuideItem | ComponentItemsWasteSortingCardsItem | ComponentItemsWorkshopDate | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentSectionsArticles | ComponentSectionsArticlesHomepageSection | ComponentSectionsBanner | ComponentSectionsBoardMembers | ComponentSectionsBranches | ComponentSectionsCardSlider | ComponentSectionsCardsList | ComponentSectionsColumns | ComponentSectionsColumnsList | ComponentSectionsContacts | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaq | ComponentSectionsFaqCategories | ComponentSectionsFiles | ComponentSectionsFormCtaBanner | ComponentSectionsGlobalSearch | ComponentSectionsHeroHomepageSection | ComponentSectionsImageAndText | ComponentSectionsImageAndTextOverlapped | ComponentSectionsKoloHomepageSection | ComponentSectionsOpeningTimes | ComponentSectionsOrderedCards | ComponentSectionsRichtext | ComponentSectionsServices | ComponentSectionsServicesHomepageSection | ComponentSectionsSortingGuide | ComponentSectionsSortingGuideAccordions | ComponentSectionsTable | ComponentSectionsVacancies | ComponentSectionsWasteSortingCards | ComponentSectionsWorkshops | Contact | Document | DocumentCategory | Faq | FaqCategory | Footer | Homepage | I18NLocale | Menu | Navigation | OpeningTime | Page | Service | ServiceCategory | Tag | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | Workshop
+union GenericMorph = Article | ArticleCategory | Branch | ComponentHeaderSectionsBranchMap | ComponentHeaderSectionsCareers | ComponentHeaderSectionsFeaturedNews | ComponentHeaderSectionsGallery | ComponentHeaderSectionsIcon | ComponentHeaderSectionsImage | ComponentHeaderSectionsPickupDay | ComponentHeaderSectionsSideImage | ComponentItemsAnchor | ComponentItemsBoardMembersItem | ComponentItemsCardSliderCard | ComponentItemsCardsListItem | ComponentItemsColumnsItem | ComponentItemsColumnsListItem | ComponentItemsFileItem | ComponentItemsFooterColumn | ComponentItemsHeroMainTile | ComponentItemsHeroSmallTile | ComponentItemsHomepageServiceTile | ComponentItemsImageAndTextOverlappedItem | ComponentItemsLink | ComponentItemsMenuHeader | ComponentItemsOpeningHoursItem | ComponentItemsOpeningTimesItem | ComponentItemsOrderedCardsItem | ComponentItemsSlide | ComponentItemsSortingGuide | ComponentItemsSortingGuideAccordionItem | ComponentItemsSortingGuideAlertMessage | ComponentItemsSortingGuideItem | ComponentItemsWasteSortingCardsItem | ComponentItemsWorkshopDate | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentSectionsArticles | ComponentSectionsArticlesHomepageSection | ComponentSectionsBanner | ComponentSectionsBoardMembers | ComponentSectionsBranches | ComponentSectionsCardSlider | ComponentSectionsCardsList | ComponentSectionsColumns | ComponentSectionsColumnsList | ComponentSectionsContacts | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaq | ComponentSectionsFaqCategories | ComponentSectionsFiles | ComponentSectionsFormCtaBanner | ComponentSectionsGlobalSearch | ComponentSectionsHeroHomepageSection | ComponentSectionsImageAndText | ComponentSectionsImageAndTextOverlapped | ComponentSectionsKoloHomepageSection | ComponentSectionsOpeningTimes | ComponentSectionsOrderedCards | ComponentSectionsRichtext | ComponentSectionsServices | ComponentSectionsServicesHomepageSection | ComponentSectionsSortingGuide | ComponentSectionsSortingGuideAccordions | ComponentSectionsTable | ComponentSectionsVacancies | ComponentSectionsWasteSortingCards | ComponentSectionsWorkshops | Contact | Document | DocumentCategory | Faq | FaqCategory | Footer | Homepage | I18NLocale | Menu | Navigation | OpeningTime | Page | Service | ServiceCategory | Tag | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | Workshop
 
 type Homepage {
   articlesSection: ComponentSectionsArticlesHomepageSection

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -613,20 +613,20 @@ input ComponentItemsHomepageServiceTileInput {
 type ComponentItemsImageAndTextOverlappedItem {
   id: ID!
   image: UploadFileEntityResponse
-  text: String
+  title: String
 }
 
 input ComponentItemsImageAndTextOverlappedItemFiltersInput {
   and: [ComponentItemsImageAndTextOverlappedItemFiltersInput]
   not: ComponentItemsImageAndTextOverlappedItemFiltersInput
   or: [ComponentItemsImageAndTextOverlappedItemFiltersInput]
-  text: StringFilterInput
+  title: StringFilterInput
 }
 
 input ComponentItemsImageAndTextOverlappedItemInput {
   id: ID
   image: ID
-  text: String
+  title: String
 }
 
 type ComponentItemsLink {

--- a/strapi/src/components/header-sections/careers.json
+++ b/strapi/src/components/header-sections/careers.json
@@ -1,0 +1,25 @@
+{
+  "collectionName": "components_header_sections_careers",
+  "info": {
+    "displayName": "Kariéra",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "text": {
+      "type": "text"
+    },
+    "videoUrl": {
+      "type": "string",
+      "required": true
+    },
+    "imageWithText": {
+      "type": "component",
+      "repeatable": false,
+      "component": "items.image-and-text-overlapped-item"
+    }
+  }
+}

--- a/strapi/src/components/items/image-and-text-overlapped-item.json
+++ b/strapi/src/components/items/image-and-text-overlapped-item.json
@@ -10,9 +10,11 @@
       "type": "media",
       "multiple": false,
       "required": false,
-      "allowedTypes": ["images"]
+      "allowedTypes": [
+        "images"
+      ]
     },
-    "text": {
+    "title": {
       "type": "string"
     }
   }

--- a/strapi/src/components/items/image-and-text-overlapped-item.json
+++ b/strapi/src/components/items/image-and-text-overlapped-item.json
@@ -1,0 +1,19 @@
+{
+  "collectionName": "components_items_image_and_text_overlapped_items",
+  "info": {
+    "displayName": "Image and text overlapped item",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": ["images"]
+    },
+    "text": {
+      "type": "string"
+    }
+  }
+}

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -774,6 +774,18 @@ export interface ItemsLink extends Schema.Component {
   }
 }
 
+export interface ItemsImageAndTextOverlappedItem extends Schema.Component {
+  collectionName: 'components_items_image_and_text_overlapped_items'
+  info: {
+    displayName: 'Image and text overlapped item'
+    description: ''
+  }
+  attributes: {
+    image: Attribute.Media<'images'>
+    text: Attribute.String
+  }
+}
+
 export interface ItemsHomepageServiceTile extends Schema.Component {
   collectionName: 'components_items_homepage_service_tiles'
   info: {
@@ -987,6 +999,20 @@ export interface HeaderSectionsFeaturedNews extends Schema.Component {
   }
 }
 
+export interface HeaderSectionsCareers extends Schema.Component {
+  collectionName: 'components_header_sections_careers'
+  info: {
+    displayName: 'Kari\u00E9ra'
+    description: ''
+  }
+  attributes: {
+    title: Attribute.String
+    text: Attribute.Text
+    videoUrl: Attribute.String & Attribute.Required
+    imageWithText: Attribute.Component<'items.image-and-text-overlapped-item'>
+  }
+}
+
 export interface HeaderSectionsBranchMap extends Schema.Component {
   collectionName: 'components_header_sections_branch_maps'
   info: {
@@ -1049,6 +1075,7 @@ declare module '@strapi/types' {
       'items.opening-hours-item': ItemsOpeningHoursItem
       'items.menu-header': ItemsMenuHeader
       'items.link': ItemsLink
+      'items.image-and-text-overlapped-item': ItemsImageAndTextOverlappedItem
       'items.homepage-service-tile': ItemsHomepageServiceTile
       'items.hero-small-tile': ItemsHeroSmallTile
       'items.hero-main-tile': ItemsHeroMainTile
@@ -1066,6 +1093,7 @@ declare module '@strapi/types' {
       'header-sections.icon': HeaderSectionsIcon
       'header-sections.gallery': HeaderSectionsGallery
       'header-sections.featured-news': HeaderSectionsFeaturedNews
+      'header-sections.careers': HeaderSectionsCareers
       'header-sections.branch-map': HeaderSectionsBranchMap
     }
   }

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -782,7 +782,7 @@ export interface ItemsImageAndTextOverlappedItem extends Schema.Component {
   }
   attributes: {
     image: Attribute.Media<'images'>
-    text: Attribute.String
+    title: Attribute.String
   }
 }
 


### PR DESCRIPTION
- Create Careers section in Strapi
- Create React component `CareersPageHeader`
- Embed video (via iframe) within the header
- Extract the UI logic from `ImageAndTextOverlappedSection` into a separate component to allow reuse

<img width="728" alt="Screenshot 2024-09-23 at 13 17 02" src="https://github.com/user-attachments/assets/38773f36-56b8-4cce-9e34-86e246d2f315">
