### PR TITLE
#536 Add Forms content type

### DIFF
--- a/next/src/components/common/FormCtaBanner/FormCtaBanner.tsx
+++ b/next/src/components/common/FormCtaBanner/FormCtaBanner.tsx
@@ -1,11 +1,11 @@
 import Button from '@/src/components/common/Button/Button'
 import Typography from '@/src/components/common/Typography/Typography'
-import { LinkFragment } from '@/src/services/graphql/api'
+import { FormCtaBannerLinkFragment, LinkFragment } from '@/src/services/graphql/api'
 import { useGetLinkProps } from '@/src/utils/useGetLinkProps'
 
 type FormCtaBannerProps = {
   title: string
-  link: LinkFragment
+  link: LinkFragment | FormCtaBannerLinkFragment
   isFullWidthButton?: boolean
 }
 
@@ -18,7 +18,10 @@ const FormCtaBanner = ({ title, link, isFullWidthButton = false }: FormCtaBanner
 
   return (
     <div className="flex flex-col gap-4 overflow-hidden rounded-lg border border-border-default bg-background-primary p-4 lg:gap-6 lg:p-6">
-      <Typography variant="h5">{title}</Typography>
+      {/* TODO find solution how to render it as heading, but not showing in Table of Contents */}
+      <Typography variant="h5" as="p">
+        {title}
+      </Typography>
       <Button
         variant="category-solid"
         asLink

--- a/next/src/pages/[...path].tsx
+++ b/next/src/pages/[...path].tsx
@@ -66,8 +66,6 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
     return NOT_FOUND
   }
 
-  console.time('Page')
-
   const [
     { pages: entities },
     { pages: aliasPages, articles: aliasArticles },
@@ -81,8 +79,6 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
     fetchNavigation(navigationConfig),
     serverSideTranslations(locale),
   ])
-
-  console.timeLog('Page', 'after promises')
 
   let redirectPath = ''
 
@@ -125,16 +121,12 @@ export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
     return NOT_FOUND
   }
 
-  console.timeLog('Page', 'before prefetch')
-
   // Prefetch data
   const queryClient = new QueryClient()
 
   await queryClient.prefetchQuery(generalQuery(locale))
-  console.timeLog('Page', 'after generalQuery')
   await queryClient.prefetchQuery(latestArticlesQuery(LATEST_ARTICLES_COUNT, locale))
   await prefetchPageSections(queryClient, entity, locale)
-  console.timeLog('Page', 'after prefetchPageSections')
 
   const dehydratedState = dehydrate(queryClient)
 

--- a/next/src/pages/form/[slug].tsx
+++ b/next/src/pages/form/[slug].tsx
@@ -1,0 +1,148 @@
+import IframeResizer from '@iframe-resizer/react'
+import { GetStaticPaths, GetStaticProps } from 'next'
+import Head from 'next/head'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import * as React from 'react'
+import { useMemo } from 'react'
+
+import Breadcrumbs from '@/src/components/common/Breadcrumbs/Breadcrumbs'
+import Typography from '@/src/components/common/Typography/Typography'
+import PageLayout from '@/src/components/layout/PageLayout'
+import SectionContainer from '@/src/components/layout/Section/SectionContainer'
+import PageHeaderBasic from '@/src/components/sections/headers/PageHeaderBasic'
+import { GeneralContextProvider } from '@/src/providers/GeneralContextProvider'
+import { client } from '@/src/services/graphql'
+import { FormEntityFragment, GeneralQuery } from '@/src/services/graphql/api'
+import { fetchNavigation } from '@/src/services/navigation/fetchNavigation'
+import { navigationConfig } from '@/src/services/navigation/navigationConfig'
+import { NavigationObject } from '@/src/services/navigation/typesNavigation'
+import { NOT_FOUND } from '@/src/utils/conts'
+import { getPageBreadcrumbs } from '@/src/utils/getPageBreadcrumbs'
+
+type PageProps = {
+  general?: GeneralQuery
+  navigation: NavigationObject
+  entity: FormEntityFragment
+}
+
+type StaticParams = {
+  slug: string
+}
+
+export const getStaticPaths: GetStaticPaths<StaticParams> = async () => {
+  const { forms: entities } = await client.FormsStaticPaths()
+
+  const paths = (entities?.data ?? [])
+    .filter((entity) => entity?.attributes?.slug)
+    .map((entity) => ({
+      params: {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion,@typescript-eslint/no-non-null-assertion
+        slug: entity.attributes!.slug!,
+      },
+    }))
+
+  // eslint-disable-next-line no-console
+  console.log(`Forms: Generated static paths for ${paths.length} slugs.`)
+
+  return { paths, fallback: 'blocking' }
+}
+
+export const getStaticProps: GetStaticProps<PageProps, StaticParams> = async ({
+  locale,
+  params,
+}) => {
+  const slug = params?.slug
+
+  // TODO update console log so it displays correct path
+  // eslint-disable-next-line no-console
+  console.log(`Revalidating Form ${locale} ${slug}`)
+
+  if (!slug || !locale) {
+    return NOT_FOUND
+  }
+
+  const [{ forms: entities }, /* general, */ navigation, translations] = await Promise.all([
+    client.FormBySlug({ slug }),
+    // client.General({ locale }),
+    fetchNavigation(navigationConfig),
+    serverSideTranslations(locale),
+  ])
+
+  const entity = entities?.data[0]
+  if (!entity) {
+    return NOT_FOUND
+  }
+
+  return {
+    props: {
+      entity,
+      // general,
+      navigation,
+      ...translations,
+    },
+    revalidate: 1, // TODO change to 10
+  }
+}
+
+const Page = ({ entity, general, navigation }: PageProps) => {
+  // TODO consider extracting this to a hook for all detail pages
+  const parentPagePath = navigation.contentTypePathPrefixesMap.service ?? ''
+  const breadcrumbs = useMemo(
+    () => [
+      ...getPageBreadcrumbs(parentPagePath, navigation.pagePathsMap),
+      {
+        title: entity.attributes?.parentService?.data?.attributes?.title ?? '',
+        path: null,
+      }, // TODO path
+      { title: entity.attributes?.title ?? '', path: null },
+    ],
+    [
+      entity.attributes?.parentService?.data?.attributes?.title,
+      entity.attributes?.title,
+      navigation.pagePathsMap,
+      parentPagePath,
+    ],
+  )
+
+  if (!entity.attributes) {
+    return null
+  }
+
+  const { title, subtext, formSlug } = entity.attributes
+
+  // TODO move city account url to env
+  const iframeUrl = formSlug
+    ? `https://city-account-next.staging.bratislava.sk/mestske-sluzby/dev/${formSlug}?externa-sluzba=true`
+    : null
+
+  return (
+    <GeneralContextProvider general={general} navigation={navigation}>
+      {/* TODO common Head/Seo component */}
+      <Head>
+        <title>{title}</title>
+      </Head>
+
+      <PageLayout>
+        <SectionContainer background="secondary">
+          <Breadcrumbs breadcrumbs={breadcrumbs} />
+        </SectionContainer>
+        <PageHeaderBasic title={title} perex={subtext} />
+
+        {iframeUrl ? (
+          <IframeResizer
+            license="GPLv3"
+            src={iframeUrl}
+            style={{ width: '100%', height: '100vh' }}
+          />
+        ) : (
+          <SectionContainer>
+            {/* eslint-disable-next-line i18next/no-literal-string */}
+            <Typography>No form slug provided.</Typography>
+          </SectionContainer>
+        )}
+      </PageLayout>
+    </GeneralContextProvider>
+  )
+}
+
+export default Page

--- a/next/src/pages/form/index.tsx
+++ b/next/src/pages/form/index.tsx
@@ -11,6 +11,8 @@ import { fetchNavigation } from '@/src/services/navigation/fetchNavigation'
 import { navigationConfig } from '@/src/services/navigation/navigationConfig'
 import { NavigationObject } from '@/src/services/navigation/typesNavigation'
 
+// TODO remove this page
+
 type PageProps = {
   general: GeneralQuery
   navigation: NavigationObject
@@ -38,7 +40,7 @@ const Page = ({ general, navigation }: PageProps) => {
       <PageLayout>
         <IframeResizer
           license="GPLv3"
-          src="https://city-account-next.staging.bratislava.sk/mestske-sluzby/dev/olo-mimoriadny-odvoz-a-likvidacia-odpadu?externa-sluzba=true"
+          src="https://city-account-next.staging.bratislava.sk/mestske-sluzby/dev/olo-mimoriadny-odvoz-a-zhodnotenie-odpadu?externa-sluzba=true"
           style={{ width: '100%', height: '100vh' }}
         />
       </PageLayout>

--- a/next/src/services/graphql/api.ts
+++ b/next/src/services/graphql/api.ts
@@ -2031,9 +2031,10 @@ export type FooterRelationResponseCollection = {
 export type Form = {
   __typename?: 'Form'
   createdAt?: Maybe<Scalars['DateTime']['output']>
-  formSlug: Scalars['String']['output']
+  formSlug?: Maybe<Scalars['String']['output']>
   parentService?: Maybe<ServiceEntityResponse>
-  text?: Maybe<Scalars['String']['output']>
+  slug: Scalars['String']['output']
+  subtext?: Maybe<Scalars['String']['output']>
   title: Scalars['String']['output']
   updatedAt?: Maybe<Scalars['DateTime']['output']>
 }
@@ -2063,7 +2064,8 @@ export type FormFiltersInput = {
   not?: InputMaybe<FormFiltersInput>
   or?: InputMaybe<Array<InputMaybe<FormFiltersInput>>>
   parentService?: InputMaybe<ServiceFiltersInput>
-  text?: InputMaybe<StringFilterInput>
+  slug?: InputMaybe<StringFilterInput>
+  subtext?: InputMaybe<StringFilterInput>
   title?: InputMaybe<StringFilterInput>
   updatedAt?: InputMaybe<DateTimeFilterInput>
 }
@@ -2071,7 +2073,8 @@ export type FormFiltersInput = {
 export type FormInput = {
   formSlug?: InputMaybe<Scalars['String']['input']>
   parentService?: InputMaybe<Scalars['ID']['input']>
-  text?: InputMaybe<Scalars['String']['input']>
+  slug?: InputMaybe<Scalars['String']['input']>
+  subtext?: InputMaybe<Scalars['String']['input']>
   title?: InputMaybe<Scalars['String']['input']>
 }
 
@@ -11834,14 +11837,21 @@ export type FooterEntityFragment = {
   } | null
 }
 
+export type FormSlugEntityFragment = {
+  __typename?: 'FormEntity'
+  id?: string | null
+  attributes?: { __typename?: 'Form'; title: string; slug: string } | null
+}
+
 export type FormEntityFragment = {
   __typename?: 'FormEntity'
   id?: string | null
   attributes?: {
     __typename?: 'Form'
+    subtext?: string | null
+    formSlug?: string | null
     title: string
-    text?: string | null
-    formSlug: string
+    slug: string
     parentService?: {
       __typename?: 'ServiceEntityResponse'
       data?: {
@@ -11853,205 +11863,43 @@ export type FormEntityFragment = {
   } | null
 }
 
+export type FormsStaticPathsQueryVariables = Exact<{ [key: string]: never }>
+
+export type FormsStaticPathsQuery = {
+  __typename?: 'Query'
+  forms?: {
+    __typename?: 'FormEntityResponseCollection'
+    data: Array<{
+      __typename?: 'FormEntity'
+      id?: string | null
+      attributes?: { __typename?: 'Form'; title: string; slug: string } | null
+    }>
+  } | null
+}
+
 export type FormBySlugQueryVariables = Exact<{
-  locale: Scalars['I18NLocaleCode']['input']
+  slug: Scalars['String']['input']
 }>
 
 export type FormBySlugQuery = {
   __typename?: 'Query'
-  faqs?: {
-    __typename?: 'FaqEntityResponseCollection'
+  forms?: {
+    __typename?: 'FormEntityResponseCollection'
     data: Array<{
-      __typename?: 'FaqEntity'
+      __typename?: 'FormEntity'
       id?: string | null
       attributes?: {
-        __typename?: 'Faq'
+        __typename?: 'Form'
+        subtext?: string | null
+        formSlug?: string | null
         title: string
-        content: string
-        faqCategory?: {
-          __typename?: 'FaqCategoryEntityResponse'
+        slug: string
+        parentService?: {
+          __typename?: 'ServiceEntityResponse'
           data?: {
-            __typename: 'FaqCategoryEntity'
+            __typename: 'ServiceEntity'
             id?: string | null
-            attributes?: {
-              __typename?: 'FaqCategory'
-              slug: string
-              title: string
-              faqs?: {
-                __typename?: 'FaqRelationResponseCollection'
-                data: Array<{
-                  __typename?: 'FaqEntity'
-                  id?: string | null
-                  attributes?: { __typename?: 'Faq'; title: string; content: string } | null
-                }>
-              } | null
-              banner?: {
-                __typename?: 'ComponentSectionsBanner'
-                text?: string | null
-                variant: Enum_Componentsectionsbanner_Variant
-                titleRequired: string
-                image: {
-                  __typename?: 'UploadFileEntityResponse'
-                  data?: {
-                    __typename?: 'UploadFileEntity'
-                    id?: string | null
-                    attributes?: {
-                      __typename?: 'UploadFile'
-                      url: string
-                      width?: number | null
-                      height?: number | null
-                      caption?: string | null
-                      alternativeText?: string | null
-                      name: string
-                    } | null
-                  } | null
-                }
-                primaryButtonLink: {
-                  __typename?: 'ComponentItemsLink'
-                  label?: string | null
-                  url?: string | null
-                  page?: {
-                    __typename?: 'PageEntityResponse'
-                    data?: {
-                      __typename: 'PageEntity'
-                      id?: string | null
-                      attributes?: { __typename?: 'Page'; title: string; slug: string } | null
-                    } | null
-                  } | null
-                  article?: {
-                    __typename?: 'ArticleEntityResponse'
-                    data?: {
-                      __typename: 'ArticleEntity'
-                      id?: string | null
-                      attributes?: { __typename?: 'Article'; slug: string; title: string } | null
-                    } | null
-                  } | null
-                  branch?: {
-                    __typename?: 'BranchEntityResponse'
-                    data?: {
-                      __typename: 'BranchEntity'
-                      id?: string | null
-                      attributes?: {
-                        __typename?: 'Branch'
-                        title: string
-                        page?: {
-                          __typename?: 'PageEntityResponse'
-                          data?: {
-                            __typename: 'PageEntity'
-                            id?: string | null
-                            attributes?: { __typename?: 'Page'; title: string; slug: string } | null
-                          } | null
-                        } | null
-                      } | null
-                    } | null
-                  } | null
-                  document?: {
-                    __typename?: 'DocumentEntityResponse'
-                    data?: {
-                      __typename: 'DocumentEntity'
-                      id?: string | null
-                      attributes?: { __typename?: 'Document'; slug: string; title: string } | null
-                    } | null
-                  } | null
-                  service?: {
-                    __typename?: 'ServiceEntityResponse'
-                    data?: {
-                      __typename: 'ServiceEntity'
-                      id?: string | null
-                      attributes?: { __typename?: 'Service'; title: string; slug: string } | null
-                    } | null
-                  } | null
-                  workshop?: {
-                    __typename?: 'WorkshopEntityResponse'
-                    data?: {
-                      __typename: 'WorkshopEntity'
-                      id?: string | null
-                      attributes?: {
-                        __typename?: 'Workshop'
-                        title: string
-                        slug: string
-                        dates?: Array<{
-                          __typename?: 'ComponentItemsWorkshopDate'
-                          datetime: any
-                        } | null> | null
-                      } | null
-                    } | null
-                  } | null
-                }
-                secondaryButtonLink?: {
-                  __typename?: 'ComponentItemsLink'
-                  label?: string | null
-                  url?: string | null
-                  page?: {
-                    __typename?: 'PageEntityResponse'
-                    data?: {
-                      __typename: 'PageEntity'
-                      id?: string | null
-                      attributes?: { __typename?: 'Page'; title: string; slug: string } | null
-                    } | null
-                  } | null
-                  article?: {
-                    __typename?: 'ArticleEntityResponse'
-                    data?: {
-                      __typename: 'ArticleEntity'
-                      id?: string | null
-                      attributes?: { __typename?: 'Article'; slug: string; title: string } | null
-                    } | null
-                  } | null
-                  branch?: {
-                    __typename?: 'BranchEntityResponse'
-                    data?: {
-                      __typename: 'BranchEntity'
-                      id?: string | null
-                      attributes?: {
-                        __typename?: 'Branch'
-                        title: string
-                        page?: {
-                          __typename?: 'PageEntityResponse'
-                          data?: {
-                            __typename: 'PageEntity'
-                            id?: string | null
-                            attributes?: { __typename?: 'Page'; title: string; slug: string } | null
-                          } | null
-                        } | null
-                      } | null
-                    } | null
-                  } | null
-                  document?: {
-                    __typename?: 'DocumentEntityResponse'
-                    data?: {
-                      __typename: 'DocumentEntity'
-                      id?: string | null
-                      attributes?: { __typename?: 'Document'; slug: string; title: string } | null
-                    } | null
-                  } | null
-                  service?: {
-                    __typename?: 'ServiceEntityResponse'
-                    data?: {
-                      __typename: 'ServiceEntity'
-                      id?: string | null
-                      attributes?: { __typename?: 'Service'; title: string; slug: string } | null
-                    } | null
-                  } | null
-                  workshop?: {
-                    __typename?: 'WorkshopEntityResponse'
-                    data?: {
-                      __typename: 'WorkshopEntity'
-                      id?: string | null
-                      attributes?: {
-                        __typename?: 'Workshop'
-                        title: string
-                        slug: string
-                        dates?: Array<{
-                          __typename?: 'ComponentItemsWorkshopDate'
-                          datetime: any
-                        } | null> | null
-                      } | null
-                    } | null
-                  } | null
-                } | null
-              } | null
-            } | null
+            attributes?: { __typename?: 'Service'; title: string; slug: string } | null
           } | null
         } | null
       } | null
@@ -27180,12 +27028,20 @@ export const FooterEntityFragmentDoc = gql`
   }
   ${FooterFragmentDoc}
 `
-export const FormEntityFragmentDoc = gql`
-  fragment FormEntity on FormEntity {
+export const FormSlugEntityFragmentDoc = gql`
+  fragment FormSlugEntity on FormEntity {
     id
     attributes {
       title
-      text
+      slug
+    }
+  }
+`
+export const FormEntityFragmentDoc = gql`
+  fragment FormEntity on FormEntity {
+    ...FormSlugEntity
+    attributes {
+      subtext
       formSlug
       parentService {
         data {
@@ -27194,6 +27050,7 @@ export const FormEntityFragmentDoc = gql`
       }
     }
   }
+  ${FormSlugEntityFragmentDoc}
   ${ServiceSlugEntityFragmentDoc}
 `
 export const UploadImageEntityFragmentDoc = gql`
@@ -28661,15 +28518,25 @@ export const FaqsDocument = gql`
   }
   ${FaqEntityFragmentDoc}
 `
-export const FormBySlugDocument = gql`
-  query FormBySlug($locale: I18NLocaleCode!) {
-    faqs(locale: $locale) {
+export const FormsStaticPathsDocument = gql`
+  query FormsStaticPaths {
+    forms(pagination: { limit: -1 }) {
       data {
-        ...FaqEntity
+        ...FormSlugEntity
       }
     }
   }
-  ${FaqEntityFragmentDoc}
+  ${FormSlugEntityFragmentDoc}
+`
+export const FormBySlugDocument = gql`
+  query FormBySlug($slug: String!) {
+    forms(filters: { slug: { eq: $slug } }) {
+      data {
+        ...FormEntity
+      }
+    }
+  }
+  ${FormEntityFragmentDoc}
 `
 export const HomepageDocument = gql`
   query Homepage($locale: I18NLocaleCode!) {
@@ -29161,6 +29028,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             ...wrappedRequestHeaders,
           }),
         'Faqs',
+        'query',
+        variables,
+      )
+    },
+    FormsStaticPaths(
+      variables?: FormsStaticPathsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FormsStaticPathsQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FormsStaticPathsQuery>(FormsStaticPathsDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'FormsStaticPaths',
         'query',
         variables,
       )

--- a/next/src/services/graphql/api.ts
+++ b/next/src/services/graphql/api.ts
@@ -540,6 +540,15 @@ export type ComponentItemsFooterColumnInput = {
   title?: InputMaybe<Scalars['String']['input']>
 }
 
+export type ComponentItemsFormCtaBannerLink = {
+  __typename?: 'ComponentItemsFormCtaBannerLink'
+  email?: Maybe<Scalars['String']['output']>
+  form?: Maybe<FormEntityResponse>
+  id: Scalars['ID']['output']
+  label?: Maybe<Scalars['String']['output']>
+  url?: Maybe<Scalars['String']['output']>
+}
+
 export type ComponentItemsHeroMainTile = {
   __typename?: 'ComponentItemsHeroMainTile'
   id: Scalars['ID']['output']
@@ -1206,7 +1215,7 @@ export type ComponentSectionsFilesFilesArgs = {
 
 export type ComponentSectionsFormCtaBanner = {
   __typename?: 'ComponentSectionsFormCtaBanner'
-  bannerLink: ComponentItemsLink
+  bannerLink: ComponentItemsFormCtaBannerLink
   bannerTitle: Scalars['String']['output']
   id: Scalars['ID']['output']
   text?: Maybe<Scalars['String']['output']>
@@ -2097,6 +2106,7 @@ export type GenericMorph =
   | ComponentItemsColumnsListItem
   | ComponentItemsFileItem
   | ComponentItemsFooterColumn
+  | ComponentItemsFormCtaBannerLink
   | ComponentItemsHeroMainTile
   | ComponentItemsHeroSmallTile
   | ComponentItemsHomepageServiceTile
@@ -4951,6 +4961,21 @@ export type LinkFragment = {
         slug: string
         dates?: Array<{ __typename?: 'ComponentItemsWorkshopDate'; datetime: any } | null> | null
       } | null
+    } | null
+  } | null
+}
+
+export type FormCtaBannerLinkFragment = {
+  __typename?: 'ComponentItemsFormCtaBannerLink'
+  label?: string | null
+  url?: string | null
+  email?: string | null
+  form?: {
+    __typename?: 'FormEntityResponse'
+    data?: {
+      __typename?: 'FormEntity'
+      id?: string | null
+      attributes?: { __typename?: 'Form'; title: string; slug: string } | null
     } | null
   } | null
 }
@@ -8082,71 +8107,16 @@ export type FormCtaBannerSectionFragment = {
   text?: string | null
   bannerTitle: string
   bannerLink: {
-    __typename?: 'ComponentItemsLink'
+    __typename?: 'ComponentItemsFormCtaBannerLink'
     label?: string | null
     url?: string | null
-    page?: {
-      __typename?: 'PageEntityResponse'
+    email?: string | null
+    form?: {
+      __typename?: 'FormEntityResponse'
       data?: {
-        __typename: 'PageEntity'
+        __typename?: 'FormEntity'
         id?: string | null
-        attributes?: { __typename?: 'Page'; title: string; slug: string } | null
-      } | null
-    } | null
-    article?: {
-      __typename?: 'ArticleEntityResponse'
-      data?: {
-        __typename: 'ArticleEntity'
-        id?: string | null
-        attributes?: { __typename?: 'Article'; slug: string; title: string } | null
-      } | null
-    } | null
-    branch?: {
-      __typename?: 'BranchEntityResponse'
-      data?: {
-        __typename: 'BranchEntity'
-        id?: string | null
-        attributes?: {
-          __typename?: 'Branch'
-          title: string
-          page?: {
-            __typename?: 'PageEntityResponse'
-            data?: {
-              __typename: 'PageEntity'
-              id?: string | null
-              attributes?: { __typename?: 'Page'; title: string; slug: string } | null
-            } | null
-          } | null
-        } | null
-      } | null
-    } | null
-    document?: {
-      __typename?: 'DocumentEntityResponse'
-      data?: {
-        __typename: 'DocumentEntity'
-        id?: string | null
-        attributes?: { __typename?: 'Document'; slug: string; title: string } | null
-      } | null
-    } | null
-    service?: {
-      __typename?: 'ServiceEntityResponse'
-      data?: {
-        __typename: 'ServiceEntity'
-        id?: string | null
-        attributes?: { __typename?: 'Service'; title: string; slug: string } | null
-      } | null
-    } | null
-    workshop?: {
-      __typename?: 'WorkshopEntityResponse'
-      data?: {
-        __typename: 'WorkshopEntity'
-        id?: string | null
-        attributes?: {
-          __typename?: 'Workshop'
-          title: string
-          slug: string
-          dates?: Array<{ __typename?: 'ComponentItemsWorkshopDate'; datetime: any } | null> | null
-        } | null
+        attributes?: { __typename?: 'Form'; title: string; slug: string } | null
       } | null
     } | null
   }
@@ -23222,71 +23192,16 @@ type ServiceSections_ComponentSectionsFormCtaBanner_Fragment = {
   text?: string | null
   bannerTitle: string
   bannerLink: {
-    __typename?: 'ComponentItemsLink'
+    __typename?: 'ComponentItemsFormCtaBannerLink'
     label?: string | null
     url?: string | null
-    page?: {
-      __typename?: 'PageEntityResponse'
+    email?: string | null
+    form?: {
+      __typename?: 'FormEntityResponse'
       data?: {
-        __typename: 'PageEntity'
+        __typename?: 'FormEntity'
         id?: string | null
-        attributes?: { __typename?: 'Page'; title: string; slug: string } | null
-      } | null
-    } | null
-    article?: {
-      __typename?: 'ArticleEntityResponse'
-      data?: {
-        __typename: 'ArticleEntity'
-        id?: string | null
-        attributes?: { __typename?: 'Article'; slug: string; title: string } | null
-      } | null
-    } | null
-    branch?: {
-      __typename?: 'BranchEntityResponse'
-      data?: {
-        __typename: 'BranchEntity'
-        id?: string | null
-        attributes?: {
-          __typename?: 'Branch'
-          title: string
-          page?: {
-            __typename?: 'PageEntityResponse'
-            data?: {
-              __typename: 'PageEntity'
-              id?: string | null
-              attributes?: { __typename?: 'Page'; title: string; slug: string } | null
-            } | null
-          } | null
-        } | null
-      } | null
-    } | null
-    document?: {
-      __typename?: 'DocumentEntityResponse'
-      data?: {
-        __typename: 'DocumentEntity'
-        id?: string | null
-        attributes?: { __typename?: 'Document'; slug: string; title: string } | null
-      } | null
-    } | null
-    service?: {
-      __typename?: 'ServiceEntityResponse'
-      data?: {
-        __typename: 'ServiceEntity'
-        id?: string | null
-        attributes?: { __typename?: 'Service'; title: string; slug: string } | null
-      } | null
-    } | null
-    workshop?: {
-      __typename?: 'WorkshopEntityResponse'
-      data?: {
-        __typename: 'WorkshopEntity'
-        id?: string | null
-        attributes?: {
-          __typename?: 'Workshop'
-          title: string
-          slug: string
-          dates?: Array<{ __typename?: 'ComponentItemsWorkshopDate'; datetime: any } | null> | null
-        } | null
+        attributes?: { __typename?: 'Form'; title: string; slug: string } | null
       } | null
     } | null
   }
@@ -23844,74 +23759,16 @@ export type ServiceEntityFragment = {
           text?: string | null
           bannerTitle: string
           bannerLink: {
-            __typename?: 'ComponentItemsLink'
+            __typename?: 'ComponentItemsFormCtaBannerLink'
             label?: string | null
             url?: string | null
-            page?: {
-              __typename?: 'PageEntityResponse'
+            email?: string | null
+            form?: {
+              __typename?: 'FormEntityResponse'
               data?: {
-                __typename: 'PageEntity'
+                __typename?: 'FormEntity'
                 id?: string | null
-                attributes?: { __typename?: 'Page'; title: string; slug: string } | null
-              } | null
-            } | null
-            article?: {
-              __typename?: 'ArticleEntityResponse'
-              data?: {
-                __typename: 'ArticleEntity'
-                id?: string | null
-                attributes?: { __typename?: 'Article'; slug: string; title: string } | null
-              } | null
-            } | null
-            branch?: {
-              __typename?: 'BranchEntityResponse'
-              data?: {
-                __typename: 'BranchEntity'
-                id?: string | null
-                attributes?: {
-                  __typename?: 'Branch'
-                  title: string
-                  page?: {
-                    __typename?: 'PageEntityResponse'
-                    data?: {
-                      __typename: 'PageEntity'
-                      id?: string | null
-                      attributes?: { __typename?: 'Page'; title: string; slug: string } | null
-                    } | null
-                  } | null
-                } | null
-              } | null
-            } | null
-            document?: {
-              __typename?: 'DocumentEntityResponse'
-              data?: {
-                __typename: 'DocumentEntity'
-                id?: string | null
-                attributes?: { __typename?: 'Document'; slug: string; title: string } | null
-              } | null
-            } | null
-            service?: {
-              __typename?: 'ServiceEntityResponse'
-              data?: {
-                __typename: 'ServiceEntity'
-                id?: string | null
-                attributes?: { __typename?: 'Service'; title: string; slug: string } | null
-              } | null
-            } | null
-            workshop?: {
-              __typename?: 'WorkshopEntityResponse'
-              data?: {
-                __typename: 'WorkshopEntity'
-                id?: string | null
-                attributes?: {
-                  __typename?: 'Workshop'
-                  title: string
-                  slug: string
-                  dates?: Array<{
-                    __typename?: 'ComponentItemsWorkshopDate'
-                    datetime: any
-                  } | null> | null
-                } | null
+                attributes?: { __typename?: 'Form'; title: string; slug: string } | null
               } | null
             } | null
           }
@@ -24436,74 +24293,16 @@ export type ServicesQuery = {
               text?: string | null
               bannerTitle: string
               bannerLink: {
-                __typename?: 'ComponentItemsLink'
+                __typename?: 'ComponentItemsFormCtaBannerLink'
                 label?: string | null
                 url?: string | null
-                page?: {
-                  __typename?: 'PageEntityResponse'
+                email?: string | null
+                form?: {
+                  __typename?: 'FormEntityResponse'
                   data?: {
-                    __typename: 'PageEntity'
+                    __typename?: 'FormEntity'
                     id?: string | null
-                    attributes?: { __typename?: 'Page'; title: string; slug: string } | null
-                  } | null
-                } | null
-                article?: {
-                  __typename?: 'ArticleEntityResponse'
-                  data?: {
-                    __typename: 'ArticleEntity'
-                    id?: string | null
-                    attributes?: { __typename?: 'Article'; slug: string; title: string } | null
-                  } | null
-                } | null
-                branch?: {
-                  __typename?: 'BranchEntityResponse'
-                  data?: {
-                    __typename: 'BranchEntity'
-                    id?: string | null
-                    attributes?: {
-                      __typename?: 'Branch'
-                      title: string
-                      page?: {
-                        __typename?: 'PageEntityResponse'
-                        data?: {
-                          __typename: 'PageEntity'
-                          id?: string | null
-                          attributes?: { __typename?: 'Page'; title: string; slug: string } | null
-                        } | null
-                      } | null
-                    } | null
-                  } | null
-                } | null
-                document?: {
-                  __typename?: 'DocumentEntityResponse'
-                  data?: {
-                    __typename: 'DocumentEntity'
-                    id?: string | null
-                    attributes?: { __typename?: 'Document'; slug: string; title: string } | null
-                  } | null
-                } | null
-                service?: {
-                  __typename?: 'ServiceEntityResponse'
-                  data?: {
-                    __typename: 'ServiceEntity'
-                    id?: string | null
-                    attributes?: { __typename?: 'Service'; title: string; slug: string } | null
-                  } | null
-                } | null
-                workshop?: {
-                  __typename?: 'WorkshopEntityResponse'
-                  data?: {
-                    __typename: 'WorkshopEntity'
-                    id?: string | null
-                    attributes?: {
-                      __typename?: 'Workshop'
-                      title: string
-                      slug: string
-                      dates?: Array<{
-                        __typename?: 'ComponentItemsWorkshopDate'
-                        datetime: any
-                      } | null> | null
-                    } | null
+                    attributes?: { __typename?: 'Form'; title: string; slug: string } | null
                   } | null
                 } | null
               }
@@ -25062,74 +24861,16 @@ export type ServiceBySlugQuery = {
               text?: string | null
               bannerTitle: string
               bannerLink: {
-                __typename?: 'ComponentItemsLink'
+                __typename?: 'ComponentItemsFormCtaBannerLink'
                 label?: string | null
                 url?: string | null
-                page?: {
-                  __typename?: 'PageEntityResponse'
+                email?: string | null
+                form?: {
+                  __typename?: 'FormEntityResponse'
                   data?: {
-                    __typename: 'PageEntity'
+                    __typename?: 'FormEntity'
                     id?: string | null
-                    attributes?: { __typename?: 'Page'; title: string; slug: string } | null
-                  } | null
-                } | null
-                article?: {
-                  __typename?: 'ArticleEntityResponse'
-                  data?: {
-                    __typename: 'ArticleEntity'
-                    id?: string | null
-                    attributes?: { __typename?: 'Article'; slug: string; title: string } | null
-                  } | null
-                } | null
-                branch?: {
-                  __typename?: 'BranchEntityResponse'
-                  data?: {
-                    __typename: 'BranchEntity'
-                    id?: string | null
-                    attributes?: {
-                      __typename?: 'Branch'
-                      title: string
-                      page?: {
-                        __typename?: 'PageEntityResponse'
-                        data?: {
-                          __typename: 'PageEntity'
-                          id?: string | null
-                          attributes?: { __typename?: 'Page'; title: string; slug: string } | null
-                        } | null
-                      } | null
-                    } | null
-                  } | null
-                } | null
-                document?: {
-                  __typename?: 'DocumentEntityResponse'
-                  data?: {
-                    __typename: 'DocumentEntity'
-                    id?: string | null
-                    attributes?: { __typename?: 'Document'; slug: string; title: string } | null
-                  } | null
-                } | null
-                service?: {
-                  __typename?: 'ServiceEntityResponse'
-                  data?: {
-                    __typename: 'ServiceEntity'
-                    id?: string | null
-                    attributes?: { __typename?: 'Service'; title: string; slug: string } | null
-                  } | null
-                } | null
-                workshop?: {
-                  __typename?: 'WorkshopEntityResponse'
-                  data?: {
-                    __typename: 'WorkshopEntity'
-                    id?: string | null
-                    attributes?: {
-                      __typename?: 'Workshop'
-                      title: string
-                      slug: string
-                      dates?: Array<{
-                        __typename?: 'ComponentItemsWorkshopDate'
-                        datetime: any
-                      } | null> | null
-                    } | null
+                    attributes?: { __typename?: 'Form'; title: string; slug: string } | null
                   } | null
                 } | null
               }
@@ -28204,16 +27945,29 @@ export const ServiceCardEntityFragmentDoc = gql`
   ${ServiceCategoryEntityFragmentDoc}
   ${UploadImageEntityFragmentDoc}
 `
+export const FormCtaBannerLinkFragmentDoc = gql`
+  fragment FormCtaBannerLink on ComponentItemsFormCtaBannerLink {
+    label
+    url
+    email
+    form {
+      data {
+        ...FormSlugEntity
+      }
+    }
+  }
+  ${FormSlugEntityFragmentDoc}
+`
 export const FormCtaBannerSectionFragmentDoc = gql`
   fragment FormCtaBannerSection on ComponentSectionsFormCtaBanner {
     title
     text
     bannerTitle
     bannerLink {
-      ...Link
+      ...FormCtaBannerLink
     }
   }
-  ${LinkFragmentDoc}
+  ${FormCtaBannerLinkFragmentDoc}
 `
 export const ServiceSectionsFragmentDoc = gql`
   fragment ServiceSections on ServiceSectionsDynamicZone {

--- a/next/src/services/graphql/api.ts
+++ b/next/src/services/graphql/api.ts
@@ -2028,6 +2028,53 @@ export type FooterRelationResponseCollection = {
   data: Array<FooterEntity>
 }
 
+export type Form = {
+  __typename?: 'Form'
+  createdAt?: Maybe<Scalars['DateTime']['output']>
+  formSlug: Scalars['String']['output']
+  parentService?: Maybe<ServiceEntityResponse>
+  text?: Maybe<Scalars['String']['output']>
+  title: Scalars['String']['output']
+  updatedAt?: Maybe<Scalars['DateTime']['output']>
+}
+
+export type FormEntity = {
+  __typename?: 'FormEntity'
+  attributes?: Maybe<Form>
+  id?: Maybe<Scalars['ID']['output']>
+}
+
+export type FormEntityResponse = {
+  __typename?: 'FormEntityResponse'
+  data?: Maybe<FormEntity>
+}
+
+export type FormEntityResponseCollection = {
+  __typename?: 'FormEntityResponseCollection'
+  data: Array<FormEntity>
+  meta: ResponseCollectionMeta
+}
+
+export type FormFiltersInput = {
+  and?: InputMaybe<Array<InputMaybe<FormFiltersInput>>>
+  createdAt?: InputMaybe<DateTimeFilterInput>
+  formSlug?: InputMaybe<StringFilterInput>
+  id?: InputMaybe<IdFilterInput>
+  not?: InputMaybe<FormFiltersInput>
+  or?: InputMaybe<Array<InputMaybe<FormFiltersInput>>>
+  parentService?: InputMaybe<ServiceFiltersInput>
+  text?: InputMaybe<StringFilterInput>
+  title?: InputMaybe<StringFilterInput>
+  updatedAt?: InputMaybe<DateTimeFilterInput>
+}
+
+export type FormInput = {
+  formSlug?: InputMaybe<Scalars['String']['input']>
+  parentService?: InputMaybe<Scalars['ID']['input']>
+  text?: InputMaybe<Scalars['String']['input']>
+  title?: InputMaybe<Scalars['String']['input']>
+}
+
 export type GenericMorph =
   | Article
   | ArticleCategory
@@ -2103,6 +2150,7 @@ export type GenericMorph =
   | Faq
   | FaqCategory
   | Footer
+  | Form
   | Homepage
   | I18NLocale
   | Menu
@@ -2321,6 +2369,7 @@ export type Mutation = {
   createFaqCategoryLocalization?: Maybe<FaqCategoryEntityResponse>
   createFaqLocalization?: Maybe<FaqEntityResponse>
   createFooterLocalization?: Maybe<FooterEntityResponse>
+  createForm?: Maybe<FormEntityResponse>
   createHomepageLocalization?: Maybe<HomepageEntityResponse>
   createMenuLocalization?: Maybe<MenuEntityResponse>
   createNavigationLocalization?: Maybe<NavigationEntityResponse>
@@ -2349,6 +2398,7 @@ export type Mutation = {
   deleteFaq?: Maybe<FaqEntityResponse>
   deleteFaqCategory?: Maybe<FaqCategoryEntityResponse>
   deleteFooter?: Maybe<FooterEntityResponse>
+  deleteForm?: Maybe<FormEntityResponse>
   deleteHomepage?: Maybe<HomepageEntityResponse>
   deleteMenu?: Maybe<MenuEntityResponse>
   deleteNavigation?: Maybe<NavigationEntityResponse>
@@ -2385,6 +2435,7 @@ export type Mutation = {
   updateFaqCategory?: Maybe<FaqCategoryEntityResponse>
   updateFileInfo: UploadFileEntityResponse
   updateFooter?: Maybe<FooterEntityResponse>
+  updateForm?: Maybe<FormEntityResponse>
   updateHomepage?: Maybe<HomepageEntityResponse>
   updateMenu?: Maybe<MenuEntityResponse>
   updateNavigation?: Maybe<NavigationEntityResponse>
@@ -2487,6 +2538,10 @@ export type MutationCreateFooterLocalizationArgs = {
   data?: InputMaybe<FooterInput>
   id?: InputMaybe<Scalars['ID']['input']>
   locale?: InputMaybe<Scalars['I18NLocaleCode']['input']>
+}
+
+export type MutationCreateFormArgs = {
+  data: FormInput
 }
 
 export type MutationCreateHomepageLocalizationArgs = {
@@ -2615,6 +2670,10 @@ export type MutationDeleteFaqCategoryArgs = {
 
 export type MutationDeleteFooterArgs = {
   locale?: InputMaybe<Scalars['I18NLocaleCode']['input']>
+}
+
+export type MutationDeleteFormArgs = {
+  id: Scalars['ID']['input']
 }
 
 export type MutationDeleteHomepageArgs = {
@@ -2760,6 +2819,11 @@ export type MutationUpdateFileInfoArgs = {
 export type MutationUpdateFooterArgs = {
   data: FooterInput
   locale?: InputMaybe<Scalars['I18NLocaleCode']['input']>
+}
+
+export type MutationUpdateFormArgs = {
+  data: FormInput
+  id: Scalars['ID']['input']
 }
 
 export type MutationUpdateHomepageArgs = {
@@ -3100,6 +3164,8 @@ export type Query = {
   faqCategory?: Maybe<FaqCategoryEntityResponse>
   faqs?: Maybe<FaqEntityResponseCollection>
   footer?: Maybe<FooterEntityResponse>
+  form?: Maybe<FormEntityResponse>
+  forms?: Maybe<FormEntityResponseCollection>
   homepage?: Maybe<HomepageEntityResponse>
   i18NLocale?: Maybe<I18NLocaleEntityResponse>
   i18NLocales?: Maybe<I18NLocaleEntityResponseCollection>
@@ -3230,6 +3296,16 @@ export type QueryFaqsArgs = {
 
 export type QueryFooterArgs = {
   locale?: InputMaybe<Scalars['I18NLocaleCode']['input']>
+}
+
+export type QueryFormArgs = {
+  id?: InputMaybe<Scalars['ID']['input']>
+}
+
+export type QueryFormsArgs = {
+  filters?: InputMaybe<FormFiltersInput>
+  pagination?: InputMaybe<PaginationArg>
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
 }
 
 export type QueryHomepageArgs = {
@@ -11755,6 +11831,231 @@ export type FooterEntityFragment = {
         } | null
       } | null
     } | null> | null
+  } | null
+}
+
+export type FormEntityFragment = {
+  __typename?: 'FormEntity'
+  id?: string | null
+  attributes?: {
+    __typename?: 'Form'
+    title: string
+    text?: string | null
+    formSlug: string
+    parentService?: {
+      __typename?: 'ServiceEntityResponse'
+      data?: {
+        __typename: 'ServiceEntity'
+        id?: string | null
+        attributes?: { __typename?: 'Service'; title: string; slug: string } | null
+      } | null
+    } | null
+  } | null
+}
+
+export type FormBySlugQueryVariables = Exact<{
+  locale: Scalars['I18NLocaleCode']['input']
+}>
+
+export type FormBySlugQuery = {
+  __typename?: 'Query'
+  faqs?: {
+    __typename?: 'FaqEntityResponseCollection'
+    data: Array<{
+      __typename?: 'FaqEntity'
+      id?: string | null
+      attributes?: {
+        __typename?: 'Faq'
+        title: string
+        content: string
+        faqCategory?: {
+          __typename?: 'FaqCategoryEntityResponse'
+          data?: {
+            __typename: 'FaqCategoryEntity'
+            id?: string | null
+            attributes?: {
+              __typename?: 'FaqCategory'
+              slug: string
+              title: string
+              faqs?: {
+                __typename?: 'FaqRelationResponseCollection'
+                data: Array<{
+                  __typename?: 'FaqEntity'
+                  id?: string | null
+                  attributes?: { __typename?: 'Faq'; title: string; content: string } | null
+                }>
+              } | null
+              banner?: {
+                __typename?: 'ComponentSectionsBanner'
+                text?: string | null
+                variant: Enum_Componentsectionsbanner_Variant
+                titleRequired: string
+                image: {
+                  __typename?: 'UploadFileEntityResponse'
+                  data?: {
+                    __typename?: 'UploadFileEntity'
+                    id?: string | null
+                    attributes?: {
+                      __typename?: 'UploadFile'
+                      url: string
+                      width?: number | null
+                      height?: number | null
+                      caption?: string | null
+                      alternativeText?: string | null
+                      name: string
+                    } | null
+                  } | null
+                }
+                primaryButtonLink: {
+                  __typename?: 'ComponentItemsLink'
+                  label?: string | null
+                  url?: string | null
+                  page?: {
+                    __typename?: 'PageEntityResponse'
+                    data?: {
+                      __typename: 'PageEntity'
+                      id?: string | null
+                      attributes?: { __typename?: 'Page'; title: string; slug: string } | null
+                    } | null
+                  } | null
+                  article?: {
+                    __typename?: 'ArticleEntityResponse'
+                    data?: {
+                      __typename: 'ArticleEntity'
+                      id?: string | null
+                      attributes?: { __typename?: 'Article'; slug: string; title: string } | null
+                    } | null
+                  } | null
+                  branch?: {
+                    __typename?: 'BranchEntityResponse'
+                    data?: {
+                      __typename: 'BranchEntity'
+                      id?: string | null
+                      attributes?: {
+                        __typename?: 'Branch'
+                        title: string
+                        page?: {
+                          __typename?: 'PageEntityResponse'
+                          data?: {
+                            __typename: 'PageEntity'
+                            id?: string | null
+                            attributes?: { __typename?: 'Page'; title: string; slug: string } | null
+                          } | null
+                        } | null
+                      } | null
+                    } | null
+                  } | null
+                  document?: {
+                    __typename?: 'DocumentEntityResponse'
+                    data?: {
+                      __typename: 'DocumentEntity'
+                      id?: string | null
+                      attributes?: { __typename?: 'Document'; slug: string; title: string } | null
+                    } | null
+                  } | null
+                  service?: {
+                    __typename?: 'ServiceEntityResponse'
+                    data?: {
+                      __typename: 'ServiceEntity'
+                      id?: string | null
+                      attributes?: { __typename?: 'Service'; title: string; slug: string } | null
+                    } | null
+                  } | null
+                  workshop?: {
+                    __typename?: 'WorkshopEntityResponse'
+                    data?: {
+                      __typename: 'WorkshopEntity'
+                      id?: string | null
+                      attributes?: {
+                        __typename?: 'Workshop'
+                        title: string
+                        slug: string
+                        dates?: Array<{
+                          __typename?: 'ComponentItemsWorkshopDate'
+                          datetime: any
+                        } | null> | null
+                      } | null
+                    } | null
+                  } | null
+                }
+                secondaryButtonLink?: {
+                  __typename?: 'ComponentItemsLink'
+                  label?: string | null
+                  url?: string | null
+                  page?: {
+                    __typename?: 'PageEntityResponse'
+                    data?: {
+                      __typename: 'PageEntity'
+                      id?: string | null
+                      attributes?: { __typename?: 'Page'; title: string; slug: string } | null
+                    } | null
+                  } | null
+                  article?: {
+                    __typename?: 'ArticleEntityResponse'
+                    data?: {
+                      __typename: 'ArticleEntity'
+                      id?: string | null
+                      attributes?: { __typename?: 'Article'; slug: string; title: string } | null
+                    } | null
+                  } | null
+                  branch?: {
+                    __typename?: 'BranchEntityResponse'
+                    data?: {
+                      __typename: 'BranchEntity'
+                      id?: string | null
+                      attributes?: {
+                        __typename?: 'Branch'
+                        title: string
+                        page?: {
+                          __typename?: 'PageEntityResponse'
+                          data?: {
+                            __typename: 'PageEntity'
+                            id?: string | null
+                            attributes?: { __typename?: 'Page'; title: string; slug: string } | null
+                          } | null
+                        } | null
+                      } | null
+                    } | null
+                  } | null
+                  document?: {
+                    __typename?: 'DocumentEntityResponse'
+                    data?: {
+                      __typename: 'DocumentEntity'
+                      id?: string | null
+                      attributes?: { __typename?: 'Document'; slug: string; title: string } | null
+                    } | null
+                  } | null
+                  service?: {
+                    __typename?: 'ServiceEntityResponse'
+                    data?: {
+                      __typename: 'ServiceEntity'
+                      id?: string | null
+                      attributes?: { __typename?: 'Service'; title: string; slug: string } | null
+                    } | null
+                  } | null
+                  workshop?: {
+                    __typename?: 'WorkshopEntityResponse'
+                    data?: {
+                      __typename: 'WorkshopEntity'
+                      id?: string | null
+                      attributes?: {
+                        __typename?: 'Workshop'
+                        title: string
+                        slug: string
+                        dates?: Array<{
+                          __typename?: 'ComponentItemsWorkshopDate'
+                          datetime: any
+                        } | null> | null
+                      } | null
+                    } | null
+                  } | null
+                } | null
+              } | null
+            } | null
+          } | null
+        } | null
+      } | null
+    }>
   } | null
 }
 
@@ -26879,6 +27180,22 @@ export const FooterEntityFragmentDoc = gql`
   }
   ${FooterFragmentDoc}
 `
+export const FormEntityFragmentDoc = gql`
+  fragment FormEntity on FormEntity {
+    id
+    attributes {
+      title
+      text
+      formSlug
+      parentService {
+        data {
+          ...ServiceSlugEntity
+        }
+      }
+    }
+  }
+  ${ServiceSlugEntityFragmentDoc}
+`
 export const UploadImageEntityFragmentDoc = gql`
   fragment UploadImageEntity on UploadFileEntity {
     id
@@ -28344,6 +28661,16 @@ export const FaqsDocument = gql`
   }
   ${FaqEntityFragmentDoc}
 `
+export const FormBySlugDocument = gql`
+  query FormBySlug($locale: I18NLocaleCode!) {
+    faqs(locale: $locale) {
+      data {
+        ...FaqEntity
+      }
+    }
+  }
+  ${FaqEntityFragmentDoc}
+`
 export const HomepageDocument = gql`
   query Homepage($locale: I18NLocaleCode!) {
     homepage(locale: $locale) {
@@ -28834,6 +29161,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             ...wrappedRequestHeaders,
           }),
         'Faqs',
+        'query',
+        variables,
+      )
+    },
+    FormBySlug(
+      variables: FormBySlugQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<FormBySlugQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<FormBySlugQuery>(FormBySlugDocument, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'FormBySlug',
         'query',
         variables,
       )

--- a/next/src/services/graphql/queries/_common.gql
+++ b/next/src/services/graphql/queries/_common.gql
@@ -33,6 +33,17 @@ fragment Link on ComponentItemsLink {
   }
 }
 
+fragment FormCtaBannerLink on ComponentItemsFormCtaBannerLink {
+  label
+  url
+  email
+  form {
+    data {
+      ...FormSlugEntity
+    }
+  }
+}
+
 fragment Anchor on ComponentItemsAnchor {
   label
   targetId

--- a/next/src/services/graphql/queries/_page-sections.gql
+++ b/next/src/services/graphql/queries/_page-sections.gql
@@ -283,7 +283,7 @@ fragment FormCtaBannerSection on ComponentSectionsFormCtaBanner {
   text
   bannerTitle
   bannerLink {
-    ...Link
+    ...FormCtaBannerLink
   }
 }
 

--- a/next/src/services/graphql/queries/forms.gql
+++ b/next/src/services/graphql/queries/forms.gql
@@ -1,8 +1,15 @@
-fragment FormEntity on FormEntity {
+fragment FormSlugEntity on FormEntity {
   id
   attributes {
     title
-    text
+    slug
+  }
+}
+
+fragment FormEntity on FormEntity {
+  ...FormSlugEntity
+  attributes {
+    subtext
     formSlug
     parentService {
       data {
@@ -12,10 +19,18 @@ fragment FormEntity on FormEntity {
   }
 }
 
-query FormBySlug($locale: I18NLocaleCode!) {
-  faqs(locale: $locale) {
+query FormsStaticPaths {
+  forms(pagination: { limit: -1 }) {
     data {
-      ...FaqEntity
+      ...FormSlugEntity
+    }
+  }
+}
+
+query FormBySlug($slug: String!) {
+  forms(filters: { slug: { eq: $slug } }) {
+    data {
+      ...FormEntity
     }
   }
 }

--- a/next/src/services/graphql/queries/forms.gql
+++ b/next/src/services/graphql/queries/forms.gql
@@ -1,0 +1,21 @@
+fragment FormEntity on FormEntity {
+  id
+  attributes {
+    title
+    text
+    formSlug
+    parentService {
+      data {
+        ...ServiceSlugEntity
+      }
+    }
+  }
+}
+
+query FormBySlug($locale: I18NLocaleCode!) {
+  faqs(locale: $locale) {
+    data {
+      ...FaqEntity
+    }
+  }
+}

--- a/next/src/services/navigation/getNavigationMiddleware.ts
+++ b/next/src/services/navigation/getNavigationMiddleware.ts
@@ -44,9 +44,9 @@ export const getNavigationMiddleware = (config: NavigationConfig) => {
       ? `${contentTypePathPrefixesMap.workshop}/`
       : null
 
-    // const pathnameString = `/${pathname.join('/')}`
-
     let destination: string | null = null
+
+    // Note that "forms" path does not need to be rewritten
 
     if (articlesPath && pathnameString.startsWith(articlesPath)) {
       destination = `/articles/${pathname.at(-1)}`

--- a/next/src/utils/useGetLinkProps.ts
+++ b/next/src/utils/useGetLinkProps.ts
@@ -1,7 +1,11 @@
 import { ReactNode } from 'react'
 
 // import { LinkPlausibleProps } from '@/src/components/common/Link/Link'
-import { LinkFragment, MenuLinkFragment } from '@/src/services/graphql/api'
+import {
+  FormCtaBannerLinkFragment,
+  LinkFragment,
+  MenuLinkFragment,
+} from '@/src/services/graphql/api'
 import { useGetFullPath } from '@/src/utils/useGetFullPath'
 
 export type LinkProps = {
@@ -9,6 +13,11 @@ export type LinkProps = {
   href: string
   target?: '_blank'
   // plausibleProps?: LinkPlausibleProps
+}
+
+// eslint-disable-next-line const-case/uppercase
+export const ROUTES = {
+  form: '/form',
 }
 
 /*
@@ -19,7 +28,9 @@ export const useGetLinkProps = () => {
   const { getFullPath } = useGetFullPath()
 
   // eslint-disable-next-line sonarjs/cognitive-complexity
-  const getLinkProps = (link: LinkFragment | MenuLinkFragment | null | undefined) => {
+  const getLinkProps = (
+    link: LinkFragment | MenuLinkFragment | FormCtaBannerLinkFragment | null | undefined,
+  ) => {
     let href = '#'
     let label = link?.label ?? ''
     let target: '_blank' | undefined
@@ -29,21 +40,27 @@ export const useGetLinkProps = () => {
     }
 
     // Some content types are not in MenuLinkFragment, so we have to check if they exist in the object
-    if (link.page?.data?.attributes) {
+    if ('page' in link && link.page?.data?.attributes) {
       label = link.label ?? link.page.data.attributes.title
       href = getFullPath(link.page.data) ?? '#'
     } else if ('article' in link && link.article?.data?.attributes) {
       label = link.label ?? link.article.data.attributes.title
       href = getFullPath(link.article.data) ?? '#'
-    } else if (link.branch?.data?.attributes) {
+    } else if ('branch' in link && link.branch?.data?.attributes) {
       label = link.label ?? link.branch.data.attributes.title
       href = getFullPath(link.branch.data) ?? '#'
-    } else if (link.workshop?.data?.attributes) {
+    } else if ('workshop' in link && link.workshop?.data?.attributes) {
       label = link.label ?? link.workshop.data.attributes.title
       href = getFullPath(link.workshop.data) ?? '#'
     } else if ('document' in link && link.document?.data?.attributes) {
       label = link.label ?? link.document.data.attributes.title
       href = getFullPath(link.document.data) ?? '#'
+    } else if ('form' in link && link.form?.data?.attributes) {
+      label = link.label ?? link.form.data.attributes.title
+      href = `${ROUTES.form}/${link.form.data.attributes.slug}` ?? '#'
+    } else if ('email' in link && link.email) {
+      label = link.label ?? link.email
+      href = `mailto:${link.email}`
     } else if (link?.url) {
       label = link.label ?? link.url
       href = link.url

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -2311,9 +2311,10 @@ type FooterRelationResponseCollection {
 
 type Form {
   createdAt: DateTime
-  formSlug: String!
+  formSlug: String
   parentService: ServiceEntityResponse
-  text: String
+  slug: String!
+  subtext: String
   title: String!
   updatedAt: DateTime
 }
@@ -2340,7 +2341,8 @@ input FormFiltersInput {
   not: FormFiltersInput
   or: [FormFiltersInput]
   parentService: ServiceFiltersInput
-  text: StringFilterInput
+  slug: StringFilterInput
+  subtext: StringFilterInput
   title: StringFilterInput
   updatedAt: DateTimeFilterInput
 }
@@ -2348,7 +2350,8 @@ input FormFiltersInput {
 input FormInput {
   formSlug: String
   parentService: ID
-  text: String
+  slug: String
+  subtext: String
   title: String
 }
 

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -2309,7 +2309,54 @@ type FooterRelationResponseCollection {
   data: [FooterEntity!]!
 }
 
-union GenericMorph = Article | ArticleCategory | Branch | ComponentHeaderSectionsBranchMap | ComponentHeaderSectionsFeaturedNews | ComponentHeaderSectionsGallery | ComponentHeaderSectionsIcon | ComponentHeaderSectionsImage | ComponentHeaderSectionsPickupDay | ComponentHeaderSectionsSideImage | ComponentItemsAnchor | ComponentItemsBoardMembersItem | ComponentItemsCardSliderCard | ComponentItemsCardsListItem | ComponentItemsColumnsItem | ComponentItemsColumnsListItem | ComponentItemsFileItem | ComponentItemsFooterColumn | ComponentItemsHeroMainTile | ComponentItemsHeroSmallTile | ComponentItemsHomepageServiceTile | ComponentItemsLink | ComponentItemsMenuHeader | ComponentItemsOpeningHoursItem | ComponentItemsOpeningTimesItem | ComponentItemsOrderedCardsItem | ComponentItemsSlide | ComponentItemsSortingGuide | ComponentItemsSortingGuideAccordionItem | ComponentItemsSortingGuideAlertMessage | ComponentItemsSortingGuideItem | ComponentItemsWasteSortingCardsItem | ComponentItemsWorkshopDate | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentSectionsArticles | ComponentSectionsArticlesHomepageSection | ComponentSectionsBanner | ComponentSectionsBoardMembers | ComponentSectionsBranches | ComponentSectionsCardSlider | ComponentSectionsCardsList | ComponentSectionsColumns | ComponentSectionsColumnsList | ComponentSectionsContacts | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaq | ComponentSectionsFaqCategories | ComponentSectionsFiles | ComponentSectionsFormCtaBanner | ComponentSectionsGlobalSearch | ComponentSectionsHeroHomepageSection | ComponentSectionsImageAndText | ComponentSectionsImageAndTextOverlapped | ComponentSectionsKoloHomepageSection | ComponentSectionsOpeningTimes | ComponentSectionsOrderedCards | ComponentSectionsRichtext | ComponentSectionsServices | ComponentSectionsServicesHomepageSection | ComponentSectionsSortingGuide | ComponentSectionsSortingGuideAccordions | ComponentSectionsTable | ComponentSectionsVacancies | ComponentSectionsWasteSortingCards | ComponentSectionsWorkshops | Contact | Document | DocumentCategory | Faq | FaqCategory | Footer | Homepage | I18NLocale | Menu | Navigation | OpeningTime | Page | Service | ServiceCategory | Tag | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | Workshop
+type Form {
+  createdAt: DateTime
+  formSlug: String!
+  parentService: ServiceEntityResponse
+  text: String
+  title: String!
+  updatedAt: DateTime
+}
+
+type FormEntity {
+  attributes: Form
+  id: ID
+}
+
+type FormEntityResponse {
+  data: FormEntity
+}
+
+type FormEntityResponseCollection {
+  data: [FormEntity!]!
+  meta: ResponseCollectionMeta!
+}
+
+input FormFiltersInput {
+  and: [FormFiltersInput]
+  createdAt: DateTimeFilterInput
+  formSlug: StringFilterInput
+  id: IDFilterInput
+  not: FormFiltersInput
+  or: [FormFiltersInput]
+  parentService: ServiceFiltersInput
+  text: StringFilterInput
+  title: StringFilterInput
+  updatedAt: DateTimeFilterInput
+}
+
+input FormInput {
+  formSlug: String
+  parentService: ID
+  text: String
+  title: String
+}
+
+type FormRelationResponseCollection {
+  data: [FormEntity!]!
+}
+
+union GenericMorph = Article | ArticleCategory | Branch | ComponentHeaderSectionsBranchMap | ComponentHeaderSectionsFeaturedNews | ComponentHeaderSectionsGallery | ComponentHeaderSectionsIcon | ComponentHeaderSectionsImage | ComponentHeaderSectionsPickupDay | ComponentHeaderSectionsSideImage | ComponentItemsAnchor | ComponentItemsBoardMembersItem | ComponentItemsCardSliderCard | ComponentItemsCardsListItem | ComponentItemsColumnsItem | ComponentItemsColumnsListItem | ComponentItemsFileItem | ComponentItemsFooterColumn | ComponentItemsHeroMainTile | ComponentItemsHeroSmallTile | ComponentItemsHomepageServiceTile | ComponentItemsLink | ComponentItemsMenuHeader | ComponentItemsOpeningHoursItem | ComponentItemsOpeningTimesItem | ComponentItemsOrderedCardsItem | ComponentItemsSlide | ComponentItemsSortingGuide | ComponentItemsSortingGuideAccordionItem | ComponentItemsSortingGuideAlertMessage | ComponentItemsSortingGuideItem | ComponentItemsWasteSortingCardsItem | ComponentItemsWorkshopDate | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentSectionsArticles | ComponentSectionsArticlesHomepageSection | ComponentSectionsBanner | ComponentSectionsBoardMembers | ComponentSectionsBranches | ComponentSectionsCardSlider | ComponentSectionsCardsList | ComponentSectionsColumns | ComponentSectionsColumnsList | ComponentSectionsContacts | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaq | ComponentSectionsFaqCategories | ComponentSectionsFiles | ComponentSectionsFormCtaBanner | ComponentSectionsGlobalSearch | ComponentSectionsHeroHomepageSection | ComponentSectionsImageAndText | ComponentSectionsImageAndTextOverlapped | ComponentSectionsKoloHomepageSection | ComponentSectionsOpeningTimes | ComponentSectionsOrderedCards | ComponentSectionsRichtext | ComponentSectionsServices | ComponentSectionsServicesHomepageSection | ComponentSectionsSortingGuide | ComponentSectionsSortingGuideAccordions | ComponentSectionsTable | ComponentSectionsVacancies | ComponentSectionsWasteSortingCards | ComponentSectionsWorkshops | Contact | Document | DocumentCategory | Faq | FaqCategory | Footer | Form | Homepage | I18NLocale | Menu | Navigation | OpeningTime | Page | Service | ServiceCategory | Tag | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | Workshop
 
 type Homepage {
   articlesSection: ComponentSectionsArticlesHomepageSection
@@ -2577,6 +2624,7 @@ type Mutation {
   createFaqCategoryLocalization(data: FaqCategoryInput, id: ID, locale: I18NLocaleCode): FaqCategoryEntityResponse
   createFaqLocalization(data: FaqInput, id: ID, locale: I18NLocaleCode): FaqEntityResponse
   createFooterLocalization(data: FooterInput, id: ID, locale: I18NLocaleCode): FooterEntityResponse
+  createForm(data: FormInput!): FormEntityResponse
   createHomepageLocalization(data: HomepageInput, id: ID, locale: I18NLocaleCode): HomepageEntityResponse
   createMenuLocalization(data: MenuInput, id: ID, locale: I18NLocaleCode): MenuEntityResponse
   createNavigationLocalization(data: NavigationInput, id: ID, locale: I18NLocaleCode): NavigationEntityResponse
@@ -2607,6 +2655,7 @@ type Mutation {
   deleteFaq(id: ID!, locale: I18NLocaleCode): FaqEntityResponse
   deleteFaqCategory(id: ID!, locale: I18NLocaleCode): FaqCategoryEntityResponse
   deleteFooter(locale: I18NLocaleCode): FooterEntityResponse
+  deleteForm(id: ID!): FormEntityResponse
   deleteHomepage(locale: I18NLocaleCode): HomepageEntityResponse
   deleteMenu(locale: I18NLocaleCode): MenuEntityResponse
   deleteNavigation(locale: I18NLocaleCode): NavigationEntityResponse
@@ -2651,6 +2700,7 @@ type Mutation {
   updateFaqCategory(data: FaqCategoryInput!, id: ID!, locale: I18NLocaleCode): FaqCategoryEntityResponse
   updateFileInfo(id: ID!, info: FileInfoInput): UploadFileEntityResponse!
   updateFooter(data: FooterInput!, locale: I18NLocaleCode): FooterEntityResponse
+  updateForm(data: FormInput!, id: ID!): FormEntityResponse
   updateHomepage(data: HomepageInput!, locale: I18NLocaleCode): HomepageEntityResponse
   updateMenu(data: MenuInput!, locale: I18NLocaleCode): MenuEntityResponse
   updateNavigation(data: NavigationInput!, locale: I18NLocaleCode): NavigationEntityResponse
@@ -2879,6 +2929,8 @@ type Query {
   faqCategory(id: ID, locale: I18NLocaleCode): FaqCategoryEntityResponse
   faqs(filters: FaqFiltersInput, locale: I18NLocaleCode, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): FaqEntityResponseCollection
   footer(locale: I18NLocaleCode): FooterEntityResponse
+  form(id: ID): FormEntityResponse
+  forms(filters: FormFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): FormEntityResponseCollection
   homepage(locale: I18NLocaleCode): HomepageEntityResponse
   i18NLocale(id: ID): I18NLocaleEntityResponse
   i18NLocales(filters: I18NLocaleFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): I18NLocaleEntityResponseCollection

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -521,6 +521,32 @@ input ComponentItemsFooterColumnInput {
   title: String
 }
 
+type ComponentItemsFormCtaBannerLink {
+  email: String
+  form: FormEntityResponse
+  id: ID!
+  label: String
+  url: String
+}
+
+input ComponentItemsFormCtaBannerLinkFiltersInput {
+  and: [ComponentItemsFormCtaBannerLinkFiltersInput]
+  email: StringFilterInput
+  form: FormFiltersInput
+  label: StringFilterInput
+  not: ComponentItemsFormCtaBannerLinkFiltersInput
+  or: [ComponentItemsFormCtaBannerLinkFiltersInput]
+  url: StringFilterInput
+}
+
+input ComponentItemsFormCtaBannerLinkInput {
+  email: String
+  form: ID
+  id: ID
+  label: String
+  url: String
+}
+
 type ComponentItemsHeroMainTile {
   id: ID!
   link: ComponentItemsLink
@@ -1332,7 +1358,7 @@ input ComponentSectionsFilesInput {
 }
 
 type ComponentSectionsFormCtaBanner {
-  bannerLink: ComponentItemsLink!
+  bannerLink: ComponentItemsFormCtaBannerLink!
   bannerTitle: String!
   id: ID!
   text: String
@@ -1341,7 +1367,7 @@ type ComponentSectionsFormCtaBanner {
 
 input ComponentSectionsFormCtaBannerFiltersInput {
   and: [ComponentSectionsFormCtaBannerFiltersInput]
-  bannerLink: ComponentItemsLinkFiltersInput
+  bannerLink: ComponentItemsFormCtaBannerLinkFiltersInput
   bannerTitle: StringFilterInput
   not: ComponentSectionsFormCtaBannerFiltersInput
   or: [ComponentSectionsFormCtaBannerFiltersInput]
@@ -1350,7 +1376,7 @@ input ComponentSectionsFormCtaBannerFiltersInput {
 }
 
 input ComponentSectionsFormCtaBannerInput {
-  bannerLink: ComponentItemsLinkInput
+  bannerLink: ComponentItemsFormCtaBannerLinkInput
   bannerTitle: String
   id: ID
   text: String
@@ -2359,7 +2385,7 @@ type FormRelationResponseCollection {
   data: [FormEntity!]!
 }
 
-union GenericMorph = Article | ArticleCategory | Branch | ComponentHeaderSectionsBranchMap | ComponentHeaderSectionsFeaturedNews | ComponentHeaderSectionsGallery | ComponentHeaderSectionsIcon | ComponentHeaderSectionsImage | ComponentHeaderSectionsPickupDay | ComponentHeaderSectionsSideImage | ComponentItemsAnchor | ComponentItemsBoardMembersItem | ComponentItemsCardSliderCard | ComponentItemsCardsListItem | ComponentItemsColumnsItem | ComponentItemsColumnsListItem | ComponentItemsFileItem | ComponentItemsFooterColumn | ComponentItemsHeroMainTile | ComponentItemsHeroSmallTile | ComponentItemsHomepageServiceTile | ComponentItemsLink | ComponentItemsMenuHeader | ComponentItemsOpeningHoursItem | ComponentItemsOpeningTimesItem | ComponentItemsOrderedCardsItem | ComponentItemsSlide | ComponentItemsSortingGuide | ComponentItemsSortingGuideAccordionItem | ComponentItemsSortingGuideAlertMessage | ComponentItemsSortingGuideItem | ComponentItemsWasteSortingCardsItem | ComponentItemsWorkshopDate | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentSectionsArticles | ComponentSectionsArticlesHomepageSection | ComponentSectionsBanner | ComponentSectionsBoardMembers | ComponentSectionsBranches | ComponentSectionsCardSlider | ComponentSectionsCardsList | ComponentSectionsColumns | ComponentSectionsColumnsList | ComponentSectionsContacts | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaq | ComponentSectionsFaqCategories | ComponentSectionsFiles | ComponentSectionsFormCtaBanner | ComponentSectionsGlobalSearch | ComponentSectionsHeroHomepageSection | ComponentSectionsImageAndText | ComponentSectionsImageAndTextOverlapped | ComponentSectionsKoloHomepageSection | ComponentSectionsOpeningTimes | ComponentSectionsOrderedCards | ComponentSectionsRichtext | ComponentSectionsServices | ComponentSectionsServicesHomepageSection | ComponentSectionsSortingGuide | ComponentSectionsSortingGuideAccordions | ComponentSectionsTable | ComponentSectionsVacancies | ComponentSectionsWasteSortingCards | ComponentSectionsWorkshops | Contact | Document | DocumentCategory | Faq | FaqCategory | Footer | Form | Homepage | I18NLocale | Menu | Navigation | OpeningTime | Page | Service | ServiceCategory | Tag | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | Workshop
+union GenericMorph = Article | ArticleCategory | Branch | ComponentHeaderSectionsBranchMap | ComponentHeaderSectionsFeaturedNews | ComponentHeaderSectionsGallery | ComponentHeaderSectionsIcon | ComponentHeaderSectionsImage | ComponentHeaderSectionsPickupDay | ComponentHeaderSectionsSideImage | ComponentItemsAnchor | ComponentItemsBoardMembersItem | ComponentItemsCardSliderCard | ComponentItemsCardsListItem | ComponentItemsColumnsItem | ComponentItemsColumnsListItem | ComponentItemsFileItem | ComponentItemsFooterColumn | ComponentItemsFormCtaBannerLink | ComponentItemsHeroMainTile | ComponentItemsHeroSmallTile | ComponentItemsHomepageServiceTile | ComponentItemsLink | ComponentItemsMenuHeader | ComponentItemsOpeningHoursItem | ComponentItemsOpeningTimesItem | ComponentItemsOrderedCardsItem | ComponentItemsSlide | ComponentItemsSortingGuide | ComponentItemsSortingGuideAccordionItem | ComponentItemsSortingGuideAlertMessage | ComponentItemsSortingGuideItem | ComponentItemsWasteSortingCardsItem | ComponentItemsWorkshopDate | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentSectionsArticles | ComponentSectionsArticlesHomepageSection | ComponentSectionsBanner | ComponentSectionsBoardMembers | ComponentSectionsBranches | ComponentSectionsCardSlider | ComponentSectionsCardsList | ComponentSectionsColumns | ComponentSectionsColumnsList | ComponentSectionsContacts | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaq | ComponentSectionsFaqCategories | ComponentSectionsFiles | ComponentSectionsFormCtaBanner | ComponentSectionsGlobalSearch | ComponentSectionsHeroHomepageSection | ComponentSectionsImageAndText | ComponentSectionsImageAndTextOverlapped | ComponentSectionsKoloHomepageSection | ComponentSectionsOpeningTimes | ComponentSectionsOrderedCards | ComponentSectionsRichtext | ComponentSectionsServices | ComponentSectionsServicesHomepageSection | ComponentSectionsSortingGuide | ComponentSectionsSortingGuideAccordions | ComponentSectionsTable | ComponentSectionsVacancies | ComponentSectionsWasteSortingCards | ComponentSectionsWorkshops | Contact | Document | DocumentCategory | Faq | FaqCategory | Footer | Form | Homepage | I18NLocale | Menu | Navigation | OpeningTime | Page | Service | ServiceCategory | Tag | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | Workshop
 
 type Homepage {
   articlesSection: ComponentSectionsArticlesHomepageSection

--- a/strapi/src/api/form/content-types/form/schema.json
+++ b/strapi/src/api/form/content-types/form/schema.json
@@ -1,0 +1,32 @@
+{
+  "kind": "collectionType",
+  "collectionName": "forms",
+  "info": {
+    "singularName": "form",
+    "pluralName": "forms",
+    "displayName": "form",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "text": {
+      "type": "text"
+    },
+    "formSlug": {
+      "type": "uid",
+      "required": true
+    },
+    "parentService": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::service.service"
+    }
+  }
+}

--- a/strapi/src/api/form/content-types/form/schema.json
+++ b/strapi/src/api/form/content-types/form/schema.json
@@ -4,7 +4,7 @@
   "info": {
     "singularName": "form",
     "pluralName": "forms",
-    "displayName": "form",
+    "displayName": "Formuláre",
     "description": ""
   },
   "options": {
@@ -16,17 +16,21 @@
       "type": "string",
       "required": true
     },
-    "text": {
-      "type": "text"
-    },
-    "formSlug": {
+    "slug": {
       "type": "uid",
+      "targetField": "title",
       "required": true
+    },
+    "subtext": {
+      "type": "text"
     },
     "parentService": {
       "type": "relation",
       "relation": "oneToOne",
       "target": "api::service.service"
+    },
+    "formSlug": {
+      "type": "string"
     }
   }
 }

--- a/strapi/src/api/form/controllers/form.ts
+++ b/strapi/src/api/form/controllers/form.ts
@@ -1,0 +1,7 @@
+/**
+ * form controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::form.form');

--- a/strapi/src/api/form/routes/form.ts
+++ b/strapi/src/api/form/routes/form.ts
@@ -1,0 +1,7 @@
+/**
+ * form router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::form.form');

--- a/strapi/src/api/form/services/form.ts
+++ b/strapi/src/api/form/services/form.ts
@@ -1,0 +1,7 @@
+/**
+ * form service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::form.form');

--- a/strapi/src/components/items/form-cta-banner-link.json
+++ b/strapi/src/components/items/form-cta-banner-link.json
@@ -1,0 +1,24 @@
+{
+  "collectionName": "components_items_form_cta_banner_links",
+  "info": {
+    "displayName": "form cta banner link",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "label": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    },
+    "email": {
+      "type": "email"
+    },
+    "form": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::form.form"
+    }
+  }
+}

--- a/strapi/src/components/sections/form-cta-banner.json
+++ b/strapi/src/components/sections/form-cta-banner.json
@@ -19,7 +19,7 @@
     "bannerLink": {
       "type": "component",
       "repeatable": false,
-      "component": "items.link",
+      "component": "items.form-cta-banner-link",
       "required": true
     }
   }

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -289,7 +289,7 @@ export interface SectionsFormCtaBanner extends Schema.Component {
     title: Attribute.String
     text: Attribute.Text
     bannerTitle: Attribute.String & Attribute.Required
-    bannerLink: Attribute.Component<'items.link'> & Attribute.Required
+    bannerLink: Attribute.Component<'items.form-cta-banner-link'> & Attribute.Required
   }
 }
 
@@ -808,6 +808,20 @@ export interface ItemsHeroMainTile extends Schema.Component {
   }
 }
 
+export interface ItemsFormCtaBannerLink extends Schema.Component {
+  collectionName: 'components_items_form_cta_banner_links'
+  info: {
+    displayName: 'form cta banner link'
+    description: ''
+  }
+  attributes: {
+    label: Attribute.String
+    url: Attribute.String
+    email: Attribute.Email
+    form: Attribute.Relation<'items.form-cta-banner-link', 'oneToOne', 'api::form.form'>
+  }
+}
+
 export interface ItemsFooterColumn extends Schema.Component {
   collectionName: 'components_items_footer_columns'
   info: {
@@ -1052,6 +1066,7 @@ declare module '@strapi/types' {
       'items.homepage-service-tile': ItemsHomepageServiceTile
       'items.hero-small-tile': ItemsHeroSmallTile
       'items.hero-main-tile': ItemsHeroMainTile
+      'items.form-cta-banner-link': ItemsFormCtaBannerLink
       'items.footer-column': ItemsFooterColumn
       'items.file-item': ItemsFileItem
       'items.columns-list-item': ItemsColumnsListItem

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -581,99 +581,6 @@ export interface MenuMenuItem extends Schema.Component {
   }
 }
 
-export interface HeaderSectionsSideImage extends Schema.Component {
-  collectionName: 'components_header_sections_side_images'
-  info: {
-    displayName: 'Obr\u00E1zok vpravo'
-    icon: 'picture'
-    description: ''
-  }
-  attributes: {
-    media: Attribute.Media<'images'> & Attribute.Required
-  }
-}
-
-export interface HeaderSectionsPickupDay extends Schema.Component {
-  collectionName: 'components_header_sections_pickup_days'
-  info: {
-    displayName: 'Odvozov\u00FD de\u0148'
-    description: ''
-  }
-  attributes: {
-    carouselTitle: Attribute.String & Attribute.Required
-    anchors: Attribute.Component<'items.anchor', true>
-    showMoreLink: Attribute.Component<'items.link'>
-  }
-}
-
-export interface HeaderSectionsImage extends Schema.Component {
-  collectionName: 'components_header_sections_images'
-  info: {
-    displayName: 'Obr\u00E1zok na cel\u00FA \u0161\u00EDrku'
-    icon: 'picture'
-    description: ''
-  }
-  attributes: {
-    media: Attribute.Media<'images'> & Attribute.Required
-  }
-}
-
-export interface HeaderSectionsIcon extends Schema.Component {
-  collectionName: 'components_header_sections_icons'
-  info: {
-    displayName: 'Ikonka'
-    description: ''
-  }
-  attributes: {
-    iconName: Attribute.String & Attribute.Required
-  }
-}
-
-export interface HeaderSectionsGallery extends Schema.Component {
-  collectionName: 'components_header_sections_galleries'
-  info: {
-    displayName: 'Gal\u00E9ria'
-    icon: 'landscape'
-    description: ''
-  }
-  attributes: {
-    medias: Attribute.Media<'images', true> & Attribute.Required
-  }
-}
-
-export interface HeaderSectionsFeaturedNews extends Schema.Component {
-  collectionName: 'components_header_sections_featured_news'
-  info: {
-    displayName: 'Aktuality (\u010Dl\u00E1nky)'
-    description: ''
-  }
-  attributes: {
-    articlesTitle: Attribute.String & Attribute.Required
-    firstArticle: Attribute.Relation<
-      'header-sections.featured-news',
-      'oneToOne',
-      'api::article.article'
-    >
-    secondArticle: Attribute.Relation<
-      'header-sections.featured-news',
-      'oneToOne',
-      'api::article.article'
-    >
-  }
-}
-
-export interface HeaderSectionsBranchMap extends Schema.Component {
-  collectionName: 'components_header_sections_branch_maps'
-  info: {
-    displayName: 'Mapa pobo\u010Diek'
-    icon: 'pinMap'
-    description: ''
-  }
-  attributes: {
-    branches: Attribute.Relation<'header-sections.branch-map', 'oneToMany', 'api::branch.branch'>
-  }
-}
-
 export interface ItemsWorkshopDate extends Schema.Component {
   collectionName: 'components_items_workshop_dates'
   info: {
@@ -999,6 +906,99 @@ export interface ItemsAnchor extends Schema.Component {
   }
 }
 
+export interface HeaderSectionsSideImage extends Schema.Component {
+  collectionName: 'components_header_sections_side_images'
+  info: {
+    displayName: 'Obr\u00E1zok vpravo'
+    icon: 'picture'
+    description: ''
+  }
+  attributes: {
+    media: Attribute.Media<'images'> & Attribute.Required
+  }
+}
+
+export interface HeaderSectionsPickupDay extends Schema.Component {
+  collectionName: 'components_header_sections_pickup_days'
+  info: {
+    displayName: 'Odvozov\u00FD de\u0148'
+    description: ''
+  }
+  attributes: {
+    carouselTitle: Attribute.String & Attribute.Required
+    anchors: Attribute.Component<'items.anchor', true>
+    showMoreLink: Attribute.Component<'items.link'>
+  }
+}
+
+export interface HeaderSectionsImage extends Schema.Component {
+  collectionName: 'components_header_sections_images'
+  info: {
+    displayName: 'Obr\u00E1zok na cel\u00FA \u0161\u00EDrku'
+    icon: 'picture'
+    description: ''
+  }
+  attributes: {
+    media: Attribute.Media<'images'> & Attribute.Required
+  }
+}
+
+export interface HeaderSectionsIcon extends Schema.Component {
+  collectionName: 'components_header_sections_icons'
+  info: {
+    displayName: 'Ikonka'
+    description: ''
+  }
+  attributes: {
+    iconName: Attribute.String & Attribute.Required
+  }
+}
+
+export interface HeaderSectionsGallery extends Schema.Component {
+  collectionName: 'components_header_sections_galleries'
+  info: {
+    displayName: 'Gal\u00E9ria'
+    icon: 'landscape'
+    description: ''
+  }
+  attributes: {
+    medias: Attribute.Media<'images', true> & Attribute.Required
+  }
+}
+
+export interface HeaderSectionsFeaturedNews extends Schema.Component {
+  collectionName: 'components_header_sections_featured_news'
+  info: {
+    displayName: 'Aktuality (\u010Dl\u00E1nky)'
+    description: ''
+  }
+  attributes: {
+    articlesTitle: Attribute.String & Attribute.Required
+    firstArticle: Attribute.Relation<
+      'header-sections.featured-news',
+      'oneToOne',
+      'api::article.article'
+    >
+    secondArticle: Attribute.Relation<
+      'header-sections.featured-news',
+      'oneToOne',
+      'api::article.article'
+    >
+  }
+}
+
+export interface HeaderSectionsBranchMap extends Schema.Component {
+  collectionName: 'components_header_sections_branch_maps'
+  info: {
+    displayName: 'Mapa pobo\u010Diek'
+    icon: 'pinMap'
+    description: ''
+  }
+  attributes: {
+    branches: Attribute.Relation<'header-sections.branch-map', 'oneToMany', 'api::branch.branch'>
+  }
+}
+
 declare module '@strapi/types' {
   export module Shared {
     export interface Components {
@@ -1037,13 +1037,6 @@ declare module '@strapi/types' {
       'menu.menu-section': MenuMenuSection
       'menu.menu-link': MenuMenuLink
       'menu.menu-item': MenuMenuItem
-      'header-sections.side-image': HeaderSectionsSideImage
-      'header-sections.pickup-day': HeaderSectionsPickupDay
-      'header-sections.image': HeaderSectionsImage
-      'header-sections.icon': HeaderSectionsIcon
-      'header-sections.gallery': HeaderSectionsGallery
-      'header-sections.featured-news': HeaderSectionsFeaturedNews
-      'header-sections.branch-map': HeaderSectionsBranchMap
       'items.workshop-date': ItemsWorkshopDate
       'items.waste-sorting-cards-item': ItemsWasteSortingCardsItem
       'items.sorting-guide': ItemsSortingGuide
@@ -1067,6 +1060,13 @@ declare module '@strapi/types' {
       'items.card-slider-card': ItemsCardSliderCard
       'items.board-members-item': ItemsBoardMembersItem
       'items.anchor': ItemsAnchor
+      'header-sections.side-image': HeaderSectionsSideImage
+      'header-sections.pickup-day': HeaderSectionsPickupDay
+      'header-sections.image': HeaderSectionsImage
+      'header-sections.icon': HeaderSectionsIcon
+      'header-sections.gallery': HeaderSectionsGallery
+      'header-sections.featured-news': HeaderSectionsFeaturedNews
+      'header-sections.branch-map': HeaderSectionsBranchMap
     }
   }
 }

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -1,58 +1,5 @@
 import type { Schema, Attribute } from '@strapi/strapi'
 
-export interface MenuMenuSection extends Schema.Component {
-  collectionName: 'components_menu_menu_sections'
-  info: {
-    displayName: 'menu section'
-    description: ''
-  }
-  attributes: {
-    label: Attribute.String & Attribute.Required
-    links: Attribute.Component<'menu.menu-link', true>
-    colSpan: Attribute.Integer &
-      Attribute.Required &
-      Attribute.SetMinMax<
-        {
-          min: 0
-          max: 3
-        },
-        number
-      > &
-      Attribute.DefaultTo<1>
-    multicolumnBehaviour: Attribute.Enumeration<['fullwidth', 'split equally']>
-    hasDividers: Attribute.Boolean & Attribute.Required & Attribute.DefaultTo<false>
-    specialSectionType: Attribute.Enumeration<['latest articles']>
-  }
-}
-
-export interface MenuMenuLink extends Schema.Component {
-  collectionName: 'components_menu_menu_link'
-  info: {
-    displayName: 'menu link'
-    description: ''
-  }
-  attributes: {
-    label: Attribute.String
-    url: Attribute.String
-    page: Attribute.Relation<'menu.menu-link', 'oneToOne', 'api::page.page'>
-    branch: Attribute.Relation<'menu.menu-link', 'oneToOne', 'api::branch.branch'>
-    service: Attribute.Relation<'menu.menu-link', 'oneToOne', 'api::service.service'>
-    workshop: Attribute.Relation<'menu.menu-link', 'oneToOne', 'api::workshop.workshop'>
-  }
-}
-
-export interface MenuMenuItem extends Schema.Component {
-  collectionName: 'components_menu_menu_items'
-  info: {
-    displayName: 'menu item'
-  }
-  attributes: {
-    label: Attribute.String & Attribute.Required
-    sections: Attribute.Component<'menu.menu-section', true>
-    seeAllLink: Attribute.Component<'items.link'>
-  }
-}
-
 export interface SectionsWorkshops extends Schema.Component {
   collectionName: 'components_sections_workshops'
   info: {
@@ -581,6 +528,152 @@ export interface SectionsArticlesHomepageSection extends Schema.Component {
   }
 }
 
+export interface MenuMenuSection extends Schema.Component {
+  collectionName: 'components_menu_menu_sections'
+  info: {
+    displayName: 'menu section'
+    description: ''
+  }
+  attributes: {
+    label: Attribute.String & Attribute.Required
+    links: Attribute.Component<'menu.menu-link', true>
+    colSpan: Attribute.Integer &
+      Attribute.Required &
+      Attribute.SetMinMax<
+        {
+          min: 0
+          max: 3
+        },
+        number
+      > &
+      Attribute.DefaultTo<1>
+    multicolumnBehaviour: Attribute.Enumeration<['fullwidth', 'split equally']>
+    hasDividers: Attribute.Boolean & Attribute.Required & Attribute.DefaultTo<false>
+    specialSectionType: Attribute.Enumeration<['latest articles']>
+  }
+}
+
+export interface MenuMenuLink extends Schema.Component {
+  collectionName: 'components_menu_menu_link'
+  info: {
+    displayName: 'menu link'
+    description: ''
+  }
+  attributes: {
+    label: Attribute.String
+    url: Attribute.String
+    page: Attribute.Relation<'menu.menu-link', 'oneToOne', 'api::page.page'>
+    branch: Attribute.Relation<'menu.menu-link', 'oneToOne', 'api::branch.branch'>
+    service: Attribute.Relation<'menu.menu-link', 'oneToOne', 'api::service.service'>
+    workshop: Attribute.Relation<'menu.menu-link', 'oneToOne', 'api::workshop.workshop'>
+  }
+}
+
+export interface MenuMenuItem extends Schema.Component {
+  collectionName: 'components_menu_menu_items'
+  info: {
+    displayName: 'menu item'
+  }
+  attributes: {
+    label: Attribute.String & Attribute.Required
+    sections: Attribute.Component<'menu.menu-section', true>
+    seeAllLink: Attribute.Component<'items.link'>
+  }
+}
+
+export interface HeaderSectionsSideImage extends Schema.Component {
+  collectionName: 'components_header_sections_side_images'
+  info: {
+    displayName: 'Obr\u00E1zok vpravo'
+    icon: 'picture'
+    description: ''
+  }
+  attributes: {
+    media: Attribute.Media<'images'> & Attribute.Required
+  }
+}
+
+export interface HeaderSectionsPickupDay extends Schema.Component {
+  collectionName: 'components_header_sections_pickup_days'
+  info: {
+    displayName: 'Odvozov\u00FD de\u0148'
+    description: ''
+  }
+  attributes: {
+    carouselTitle: Attribute.String & Attribute.Required
+    anchors: Attribute.Component<'items.anchor', true>
+    showMoreLink: Attribute.Component<'items.link'>
+  }
+}
+
+export interface HeaderSectionsImage extends Schema.Component {
+  collectionName: 'components_header_sections_images'
+  info: {
+    displayName: 'Obr\u00E1zok na cel\u00FA \u0161\u00EDrku'
+    icon: 'picture'
+    description: ''
+  }
+  attributes: {
+    media: Attribute.Media<'images'> & Attribute.Required
+  }
+}
+
+export interface HeaderSectionsIcon extends Schema.Component {
+  collectionName: 'components_header_sections_icons'
+  info: {
+    displayName: 'Ikonka'
+    description: ''
+  }
+  attributes: {
+    iconName: Attribute.String & Attribute.Required
+  }
+}
+
+export interface HeaderSectionsGallery extends Schema.Component {
+  collectionName: 'components_header_sections_galleries'
+  info: {
+    displayName: 'Gal\u00E9ria'
+    icon: 'landscape'
+    description: ''
+  }
+  attributes: {
+    medias: Attribute.Media<'images', true> & Attribute.Required
+  }
+}
+
+export interface HeaderSectionsFeaturedNews extends Schema.Component {
+  collectionName: 'components_header_sections_featured_news'
+  info: {
+    displayName: 'Aktuality (\u010Dl\u00E1nky)'
+    description: ''
+  }
+  attributes: {
+    articlesTitle: Attribute.String & Attribute.Required
+    firstArticle: Attribute.Relation<
+      'header-sections.featured-news',
+      'oneToOne',
+      'api::article.article'
+    >
+    secondArticle: Attribute.Relation<
+      'header-sections.featured-news',
+      'oneToOne',
+      'api::article.article'
+    >
+  }
+}
+
+export interface HeaderSectionsBranchMap extends Schema.Component {
+  collectionName: 'components_header_sections_branch_maps'
+  info: {
+    displayName: 'Mapa pobo\u010Diek'
+    icon: 'pinMap'
+    description: ''
+  }
+  attributes: {
+    branches: Attribute.Relation<'header-sections.branch-map', 'oneToMany', 'api::branch.branch'>
+  }
+}
+
 export interface ItemsWorkshopDate extends Schema.Component {
   collectionName: 'components_items_workshop_dates'
   info: {
@@ -906,105 +999,9 @@ export interface ItemsAnchor extends Schema.Component {
   }
 }
 
-export interface HeaderSectionsSideImage extends Schema.Component {
-  collectionName: 'components_header_sections_side_images'
-  info: {
-    displayName: 'Obr\u00E1zok vpravo'
-    icon: 'picture'
-    description: ''
-  }
-  attributes: {
-    media: Attribute.Media<'images'> & Attribute.Required
-  }
-}
-
-export interface HeaderSectionsPickupDay extends Schema.Component {
-  collectionName: 'components_header_sections_pickup_days'
-  info: {
-    displayName: 'Odvozov\u00FD de\u0148'
-    description: ''
-  }
-  attributes: {
-    carouselTitle: Attribute.String & Attribute.Required
-    anchors: Attribute.Component<'items.anchor', true>
-    showMoreLink: Attribute.Component<'items.link'>
-  }
-}
-
-export interface HeaderSectionsImage extends Schema.Component {
-  collectionName: 'components_header_sections_images'
-  info: {
-    displayName: 'Obr\u00E1zok na cel\u00FA \u0161\u00EDrku'
-    icon: 'picture'
-    description: ''
-  }
-  attributes: {
-    media: Attribute.Media<'images'> & Attribute.Required
-  }
-}
-
-export interface HeaderSectionsIcon extends Schema.Component {
-  collectionName: 'components_header_sections_icons'
-  info: {
-    displayName: 'Ikonka'
-    description: ''
-  }
-  attributes: {
-    iconName: Attribute.String & Attribute.Required
-  }
-}
-
-export interface HeaderSectionsGallery extends Schema.Component {
-  collectionName: 'components_header_sections_galleries'
-  info: {
-    displayName: 'Gal\u00E9ria'
-    icon: 'landscape'
-    description: ''
-  }
-  attributes: {
-    medias: Attribute.Media<'images', true> & Attribute.Required
-  }
-}
-
-export interface HeaderSectionsFeaturedNews extends Schema.Component {
-  collectionName: 'components_header_sections_featured_news'
-  info: {
-    displayName: 'Aktuality (\u010Dl\u00E1nky)'
-    description: ''
-  }
-  attributes: {
-    articlesTitle: Attribute.String & Attribute.Required
-    firstArticle: Attribute.Relation<
-      'header-sections.featured-news',
-      'oneToOne',
-      'api::article.article'
-    >
-    secondArticle: Attribute.Relation<
-      'header-sections.featured-news',
-      'oneToOne',
-      'api::article.article'
-    >
-  }
-}
-
-export interface HeaderSectionsBranchMap extends Schema.Component {
-  collectionName: 'components_header_sections_branch_maps'
-  info: {
-    displayName: 'Mapa pobo\u010Diek'
-    icon: 'pinMap'
-    description: ''
-  }
-  attributes: {
-    branches: Attribute.Relation<'header-sections.branch-map', 'oneToMany', 'api::branch.branch'>
-  }
-}
-
 declare module '@strapi/types' {
   export module Shared {
     export interface Components {
-      'menu.menu-section': MenuMenuSection
-      'menu.menu-link': MenuMenuLink
-      'menu.menu-item': MenuMenuItem
       'sections.workshops': SectionsWorkshops
       'sections.waste-sorting-cards': SectionsWasteSortingCards
       'sections.vacancies': SectionsVacancies
@@ -1037,6 +1034,16 @@ declare module '@strapi/types' {
       'sections.banner': SectionsBanner
       'sections.articles': SectionsArticles
       'sections.articles-homepage-section': SectionsArticlesHomepageSection
+      'menu.menu-section': MenuMenuSection
+      'menu.menu-link': MenuMenuLink
+      'menu.menu-item': MenuMenuItem
+      'header-sections.side-image': HeaderSectionsSideImage
+      'header-sections.pickup-day': HeaderSectionsPickupDay
+      'header-sections.image': HeaderSectionsImage
+      'header-sections.icon': HeaderSectionsIcon
+      'header-sections.gallery': HeaderSectionsGallery
+      'header-sections.featured-news': HeaderSectionsFeaturedNews
+      'header-sections.branch-map': HeaderSectionsBranchMap
       'items.workshop-date': ItemsWorkshopDate
       'items.waste-sorting-cards-item': ItemsWasteSortingCardsItem
       'items.sorting-guide': ItemsSortingGuide
@@ -1060,13 +1067,6 @@ declare module '@strapi/types' {
       'items.card-slider-card': ItemsCardSliderCard
       'items.board-members-item': ItemsBoardMembersItem
       'items.anchor': ItemsAnchor
-      'header-sections.side-image': HeaderSectionsSideImage
-      'header-sections.pickup-day': HeaderSectionsPickupDay
-      'header-sections.image': HeaderSectionsImage
-      'header-sections.icon': HeaderSectionsIcon
-      'header-sections.gallery': HeaderSectionsGallery
-      'header-sections.featured-news': HeaderSectionsFeaturedNews
-      'header-sections.branch-map': HeaderSectionsBranchMap
     }
   }
 }

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -1192,7 +1192,7 @@ export interface ApiFormForm extends Schema.CollectionType {
   info: {
     singularName: 'form'
     pluralName: 'forms'
-    displayName: 'form'
+    displayName: 'Formul\u00E1re'
     description: ''
   }
   options: {
@@ -1200,9 +1200,10 @@ export interface ApiFormForm extends Schema.CollectionType {
   }
   attributes: {
     title: Attribute.String & Attribute.Required
-    text: Attribute.Text
-    formSlug: Attribute.UID & Attribute.Required
+    slug: Attribute.UID<'api::form.form', 'title'> & Attribute.Required
+    subtext: Attribute.Text
     parentService: Attribute.Relation<'api::form.form', 'oneToOne', 'api::service.service'>
+    formSlug: Attribute.String
     createdAt: Attribute.DateTime
     updatedAt: Attribute.DateTime
     createdBy: Attribute.Relation<'api::form.form', 'oneToOne', 'admin::user'> & Attribute.Private

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -1187,6 +1187,29 @@ export interface ApiFooterFooter extends Schema.SingleType {
   }
 }
 
+export interface ApiFormForm extends Schema.CollectionType {
+  collectionName: 'forms'
+  info: {
+    singularName: 'form'
+    pluralName: 'forms'
+    displayName: 'form'
+    description: ''
+  }
+  options: {
+    draftAndPublish: false
+  }
+  attributes: {
+    title: Attribute.String & Attribute.Required
+    text: Attribute.Text
+    formSlug: Attribute.UID & Attribute.Required
+    parentService: Attribute.Relation<'api::form.form', 'oneToOne', 'api::service.service'>
+    createdAt: Attribute.DateTime
+    updatedAt: Attribute.DateTime
+    createdBy: Attribute.Relation<'api::form.form', 'oneToOne', 'admin::user'> & Attribute.Private
+    updatedBy: Attribute.Relation<'api::form.form', 'oneToOne', 'admin::user'> & Attribute.Private
+  }
+}
+
 export interface ApiHomepageHomepage extends Schema.SingleType {
   collectionName: 'homepages'
   info: {
@@ -1702,6 +1725,7 @@ declare module '@strapi/types' {
       'api::faq.faq': ApiFaqFaq
       'api::faq-category.faq-category': ApiFaqCategoryFaqCategory
       'api::footer.footer': ApiFooterFooter
+      'api::form.form': ApiFormForm
       'api::homepage.homepage': ApiHomepageHomepage
       'api::menu.menu': ApiMenuMenu
       'api::navigation.navigation': ApiNavigationNavigation


### PR DESCRIPTION
Commit by commit.

- add Forms content type
- add Forms detail page
- add `FormCtaBannerLink` strapi component, to be able to link to forms and add email as button link
- implement getFullPath for this new `FormCtaBannerLink` component

Note: 
- iframes with Konto probably don't work on localhost and must be tested on staging

Todo:
- delete placeholder /forms/index.tsx form
- more minor todos in code comments