### PR TITLE
#484 Adjust UI after making board members' image optional

### DIFF
--- a/next/src/components/common/BoardMemberRowGroup/BoardMemberRowGroup.stories.tsx
+++ b/next/src/components/common/BoardMemberRowGroup/BoardMemberRowGroup.stories.tsx
@@ -26,12 +26,16 @@ export const BoardMemberRowGroup: Story = {
       {
         name: 'Name',
         position: 'Position',
-        links: [{ label: 'Link 1', url: '#' }],
+        links: [
+          { label: 'Link 1', url: '#' },
+          { label: 'Link 2', url: '#' },
+        ],
         imgSrc: OloTruckImage.src,
       },
       {
         name: 'Name',
         position: 'Position',
+        links: null,
       },
       {
         name: 'Name',
@@ -39,6 +43,7 @@ export const BoardMemberRowGroup: Story = {
         links: [
           { label: 'Link 1', url: '#' },
           { label: 'Link 2', url: '#' },
+          { label: 'Link 3', url: '#' },
         ],
         imgSrc: ZevoIronHandImage.src,
       },

--- a/next/src/components/common/BoardMemberRowGroup/BoardMemberRowGroup.stories.tsx
+++ b/next/src/components/common/BoardMemberRowGroup/BoardMemberRowGroup.stories.tsx
@@ -6,7 +6,7 @@ import BoardMemberRowGroupComponent from './BoardMemberRowGroup'
 
 const meta: Meta<typeof BoardMemberRowGroupComponent> = {
   component: BoardMemberRowGroupComponent,
-  title: 'Components/BoardMemberRowGroup',
+  title: 'Components/Board Member Row Group',
   tags: ['autodocs'],
   decorators: [
     (Story) => (

--- a/next/src/components/common/BoardMemberRowGroup/BoardMemberRowGroup.stories.tsx
+++ b/next/src/components/common/BoardMemberRowGroup/BoardMemberRowGroup.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
+import { OloTruckImage, ZevoIronHandImage } from '@/src/assets/images'
+
 import BoardMemberRowGroupComponent from './BoardMemberRowGroup'
 
 const meta: Meta<typeof BoardMemberRowGroupComponent> = {
@@ -21,10 +23,36 @@ type Story = StoryObj<typeof BoardMemberRowGroupComponent>
 export const BoardMemberRowGroup: Story = {
   args: {
     BoardMemberRowCardData: [
-      { name: 'Name', position: 'Position', links: [{ label: 'Link', url: '#' }] },
-      { name: 'Name', position: 'Position', links: [{ label: 'Link', url: '#' }] },
-      { name: 'Name', position: 'Position', links: [{ label: 'Link', url: '#' }] },
+      {
+        name: 'Name',
+        position: 'Position',
+        links: [{ label: 'Link 1', url: '#' }],
+        imgSrc: OloTruckImage.src,
+      },
+      {
+        name: 'Name',
+        position: 'Position',
+      },
+      {
+        name: 'Name',
+        position: 'Position',
+        links: [
+          { label: 'Link 1', url: '#' },
+          { label: 'Link 2', url: '#' },
+        ],
+        imgSrc: ZevoIronHandImage.src,
+      },
+      {
+        name: 'Name',
+        position: 'Position',
+        links: [{ label: 'Link 1', url: '#' }],
+      },
     ],
+  },
+  parameters: {
+    controls: {
+      exclude: ['BoardMemberRowCardData', 'className'],
+    },
   },
   render: (args) => (
     <div className="w-full">

--- a/next/src/components/common/BoardMemberRowGroup/BoardMemberRowGroup.tsx
+++ b/next/src/components/common/BoardMemberRowGroup/BoardMemberRowGroup.tsx
@@ -25,11 +25,7 @@ const BoardMemberRowGroup = ({ BoardMemberRowCardData, className }: BoardMemberR
             return (
               // eslint-disable-next-line react/no-array-index-key
               <li key={index}>
-                <BoardMemberRowCard
-                  {...card}
-                  // elevate z-index to show focus ring on top of other cards
-                  className="focus-within:z-1 focus-within:ring-offset-0"
-                />
+                <BoardMemberRowCard {...card} />
               </li>
             )
           })

--- a/next/src/components/common/Card/BoardMemberRowCard.tsx
+++ b/next/src/components/common/Card/BoardMemberRowCard.tsx
@@ -10,7 +10,7 @@ export type BoardMemberRowCardProps = {
   name: string
   position: string
   imgSrc?: string | null
-  links?: LinkFragment[] | null
+  links?: LinkFragment[] | null | undefined
   className?: string
 }
 

--- a/next/src/components/common/Card/BoardMemberRowCard.tsx
+++ b/next/src/components/common/Card/BoardMemberRowCard.tsx
@@ -9,8 +9,8 @@ import { useGetLinkProps } from '@/src/utils/useGetLinkProps'
 export type BoardMemberRowCardProps = {
   name: string
   position: string
-  imgSrc?: string
-  links?: LinkFragment[] | null | undefined
+  imgSrc?: string | null
+  links?: LinkFragment[] | null
   className?: string
 }
 
@@ -44,15 +44,23 @@ const BoardMemberRowCard = ({
     : []
 
   return (
-    <div className={cn('flex flex-col gap-4 py-4', className)}>
+    <div
+      className={cn(
+        'flex flex-col py-4',
+        { 'gap-6': imgSrc || filteredLinks.length === 1 },
+        className,
+      )}
+    >
       <div className="flex gap-4">
-        {/* 7.5rem = 120px */}
-        <CardImage imgSrc={imgSrc} className="size-12 rounded-lg lg:size-[7.5rem]" />
+        {imgSrc ? (
+          // 7.5rem = 120px
+          <CardImage imgSrc={imgSrc} className="size-12 rounded-lg lg:size-[7.5rem]" />
+        ) : null}
+
         <div
-          // TODO This gap is currently only estimated so that if only one link is present, it sits at the bottom
-          className={cn('flex flex-col', {
-            'gap-13': filteredLinks.length === 1,
-            'gap-6': filteredLinks.length > 1,
+          className={cn('flex flex-col justify-between', {
+            'h-12 lg:h-[7.5rem]': filteredLinks.length > 1, // Set the container to match the image height when links are present
+            'gap-6': filteredLinks.length === 1,
           })}
         >
           <div className="flex flex-col items-start gap-1 self-stretch">

--- a/next/src/components/common/Card/BoardMemberRowCard.tsx
+++ b/next/src/components/common/Card/BoardMemberRowCard.tsx
@@ -45,11 +45,7 @@ const BoardMemberRowCard = ({
 
   return (
     <div
-      className={cn(
-        'flex flex-col py-4',
-        { 'gap-6': imgSrc || filteredLinks.length === 1 },
-        className,
-      )}
+      className={cn('flex flex-col py-4', { 'gap-4': imgSrc || filteredLinks?.length }, className)}
     >
       <div className="flex gap-4">
         {imgSrc ? (
@@ -59,8 +55,7 @@ const BoardMemberRowCard = ({
 
         <div
           className={cn('flex flex-col justify-between', {
-            'h-12 lg:h-[7.5rem]': filteredLinks.length > 1, // Set the container to match the image height when links are present
-            'gap-6': filteredLinks.length === 1,
+            'gap-6': filteredLinks?.length, // The design doesn't specify a gap for desktop, so gap-6 was chosen as suitable
           })}
         >
           <div className="flex flex-col items-start gap-1 self-stretch">


### PR DESCRIPTION
- Adjust the UI since image is now an optional field in Strapi
- Make the UI flexible to cover different use cases such as _has image and link_, _no image and link_, _no link_ etc.

<img width="398" alt="Screenshot 2024-09-23 at 21 52 08" src="https://github.com/user-attachments/assets/e23bc2d1-b96b-44ae-af85-dd01eb540e2d">
<img width="822" alt="Screenshot 2024-09-23 at 21 52 26" src="https://github.com/user-attachments/assets/3df79f58-d639-4f92-8e9f-0759469f486d">
