### PR TITLE
#407 Add options to delete collection days by type and update meili index

### DIFF
--- a/strapi/src/plugins/waste-collection-days-import/admin/src/components/DeleteSection.tsx
+++ b/strapi/src/plugins/waste-collection-days-import/admin/src/components/DeleteSection.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react'
+import { Alert, Box, Button, Link, Loader, Stack, Typography } from '@strapi/design-system'
+import axiosInstance from '../utils/axiosInstance'
+
+const deleteUrls = {
+  'waste-collection-days': '/waste-collection-days-import/delete-waste-collection-days',
+}
+
+const headerTexts = {
+  'waste-collection-days': 'Vymazanie odvozových dní',
+}
+
+const links = {
+  'waste-collection-days': () =>
+    `/content-manager/collectionType/api::waste-collection-day.waste-collection-day`,
+}
+
+type DeleteSectionProps = {
+  type: 'waste-collection-days'
+}
+
+const DeleteSection = ({ type }: DeleteSectionProps) => {
+  const [inputValue, setInputValue] = useState('')
+
+  const [loading, setLoading] = useState(false)
+  const [success, setSuccess] = useState<any>(null)
+  const [error, setError] = useState<any>(null)
+
+  const handleSubmit = () => {
+    setLoading(true)
+    setSuccess(null)
+    setError(null)
+
+    axiosInstance
+      .post(`${deleteUrls[type]}/${inputValue}`)
+      .then((response) => {
+        setSuccess(response)
+      })
+      .catch((error) => {
+        setError(error)
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }
+
+  return (
+    <Box
+      background="neutral0"
+      hasRadius
+      shadow="filterShadow"
+      paddingTop={6}
+      paddingBottom={6}
+      paddingLeft={7}
+      paddingRight={7}
+    >
+      <Stack spacing={4}>
+        <Typography variant="delta" as="h2">
+          {headerTexts[type]}
+        </Typography>
+        {loading && <Loader />}
+        {success && (
+          <Alert
+            title="Vymazanie úspešné"
+            action={
+              success.data?.importId && <Link to={links[type]()}>Prejsť na odvozové dni</Link>
+            }
+            variant="success"
+            onClose={() => setSuccess(null)}
+          >
+            {success.data.message}
+          </Alert>
+        )}
+        {error && (
+          <Alert title="Vymazanie neúspešné" variant="danger" onClose={() => setError(null)}>
+            {error?.response?.data?.message ?? error.toString()}
+          </Alert>
+        )}
+
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(event) => setInputValue(event.target.value)}
+        />
+
+        <div>
+          <Button onClick={handleSubmit} loading={loading} disabled={!inputValue}>
+            Vymazať odvozové dni podľa uvedeného typu
+          </Button>
+        </div>
+      </Stack>
+    </Box>
+  )
+}
+
+export default DeleteSection

--- a/strapi/src/plugins/waste-collection-days-import/admin/src/components/UpdateMeilisearchSection.tsx
+++ b/strapi/src/plugins/waste-collection-days-import/admin/src/components/UpdateMeilisearchSection.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react'
+import { Alert, Box, Button, Link, Loader, Stack, Typography } from '@strapi/design-system'
+import axiosInstance from '../utils/axiosInstance'
+
+const updateMeilisearchUrls = {
+  'waste-collection-days': '/waste-collection-days-import/update-meilisearch-waste-collection-days',
+}
+
+const headerTexts = {
+  'waste-collection-days': 'Aktualizácia manuálne vykonaných zmien',
+}
+
+const links = {
+  'waste-collection-days': () =>
+    `/content-manager/collectionType/api::waste-collection-day.waste-collection-day`,
+}
+
+type UpdateMeilisearchSectionProps = {
+  type: 'waste-collection-days'
+}
+
+const UpdateMeilisearchSection = ({ type }: UpdateMeilisearchSectionProps) => {
+  const [loading, setLoading] = useState(false)
+  const [success, setSuccess] = useState<any>(null)
+  const [error, setError] = useState<any>(null)
+
+  const handleSubmit = () => {
+    setLoading(true)
+    setSuccess(null)
+    setError(null)
+
+    axiosInstance
+      .post(updateMeilisearchUrls[type])
+      .then((response) => {
+        setSuccess(response)
+      })
+      .catch((error) => {
+        setError(error)
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+  }
+
+  return (
+    <Box
+      background="neutral0"
+      hasRadius
+      shadow="filterShadow"
+      paddingTop={6}
+      paddingBottom={6}
+      paddingLeft={7}
+      paddingRight={7}
+    >
+      <Stack spacing={4}>
+        <Typography variant="delta" as="h2">
+          {headerTexts[type]}
+        </Typography>
+        {loading && <Loader />}
+        {success && (
+          <Alert
+            title="Aktualizácia zmien úspešná"
+            action={success.data?.importId && <Link to={links[type]()}>Zobraziť Odvozové dni</Link>}
+            variant="success"
+            onClose={() => setSuccess(null)}
+          >
+            {success.data.message}
+          </Alert>
+        )}
+        {error && (
+          <Alert
+            title="Aktualizácia zmien neúspešná"
+            variant="danger"
+            onClose={() => setError(null)}
+          >
+            {error?.response?.data?.message ?? error.toString()}
+          </Alert>
+        )}
+        <div>
+          <Button onClick={handleSubmit} loading={loading}>
+            Aktualizovať odvozové dni
+          </Button>
+        </div>
+      </Stack>
+    </Box>
+  )
+}
+
+export default UpdateMeilisearchSection

--- a/strapi/src/plugins/waste-collection-days-import/admin/src/index.tsx
+++ b/strapi/src/plugins/waste-collection-days-import/admin/src/index.tsx
@@ -12,7 +12,7 @@ export default {
       icon: PluginIcon,
       intlLabel: {
         id: `${pluginId}.plugin.name`,
-        defaultMessage: 'Import Excel súborov',
+        defaultMessage: 'Import odvozových dní',
       },
       Component: async () => {
         const component = await import('./pages/App')

--- a/strapi/src/plugins/waste-collection-days-import/admin/src/pages/HomePage/index.tsx
+++ b/strapi/src/plugins/waste-collection-days-import/admin/src/pages/HomePage/index.tsx
@@ -9,16 +9,20 @@
 import React from 'react'
 import { Box, ContentLayout, HeaderLayout, Layout, Stack } from '@strapi/design-system'
 import ImportSection from '../../components/ImportSection'
+import DeleteSection from '../../components/DeleteSection'
+import UpdateMeilisearchSection from '../../components/UpdateMeilisearchSection'
 
 const HomePage = () => {
   return (
     <div>
       <Box background="neutral100">
         <Layout>
-          <HeaderLayout title="Import Excel súborov"></HeaderLayout>
+          <HeaderLayout title="Import odvozových dní"></HeaderLayout>
           <ContentLayout>
             <Stack spacing={4}>
               <ImportSection type={'waste-collection-days'} />
+              <DeleteSection type={'waste-collection-days'} />
+              <UpdateMeilisearchSection type={'waste-collection-days'} />
             </Stack>
           </ContentLayout>
         </Layout>

--- a/strapi/src/plugins/waste-collection-days-import/server/controllers/index.ts
+++ b/strapi/src/plugins/waste-collection-days-import/server/controllers/index.ts
@@ -3,70 +3,107 @@ import { parseWasteCollectionDaysXlsx } from '../helpers/parse-waste-collection-
 import { v4 as uuid } from 'uuid'
 
 export default {
-  importXlsxController: ({ strapi }: { strapi: Strapi }) => ({
-    async updateWasteCollectionDays(ctx) {
-      ctx.request.socket.setTimeout(300000) // 5 minutes
+  importXlsxController: ({ strapi }: { strapi: Strapi }) => {
+    const meilisearch = strapi.plugin('meilisearch').service('meilisearch')
 
-      const file = ctx.request.files?.file
-      if (!file) {
-        ctx.status = 400
-        ctx.body = {
-          message: 'Chýba súbor.',
+    // TODO: Discuss the behaviour of the import.
+    // All the entries are replaced when a new XLSX is uploaded.
+    const deleteWasteCollectionDays = async (type?: string) => {
+      await strapi.db.query('api::waste-collection-day.waste-collection-day').deleteMany({
+        where: {
+          type: type,
+        },
+      })
+      // `deleteMany` doesn't trigger Meilisearch hooks, so the old debtors stay in its database,
+      // also having Meilisearch on while adding debtors triggers the update content hook after
+      // every query, therefore the best solution is to turn the Meilisearch off while adding new debtors
+      // and turn it back on afterward.
+      // See `strapi/patches/strapi-plugin-meilisearch+0.7.1.patch`.
+      await meilisearch.emptyOrDeleteIndex({
+        contentType: 'api::waste-collection-day.waste-collection-day',
+      })
+    }
+
+    return {
+      async updateWasteCollectionDays(ctx) {
+        ctx.request.socket.setTimeout(300000) // 5 minutes
+
+        const file = ctx.request.files?.file
+        if (!file) {
+          ctx.status = 400
+          ctx.body = {
+            message: 'Chýba súbor.',
+          }
+          return
         }
-        return
-      }
-
-      const meilisearch = strapi.plugin('meilisearch').service('meilisearch')
-
-      try {
-        const importId = uuid()
-        const parsedWasteCollectionDays = parseWasteCollectionDaysXlsx(file.path, importId)
-
-        // TODO: Discuss the behaviour of the import.
-        // All the entries are replaced when a new XLSX is uploaded.
-        const deleteWasteCollectionDays = async () => {
-          await strapi.db.query('api::waste-collection-day.waste-collection-day').deleteMany({})
-          // `deleteMany` doesn't trigger Meilisearch hooks, so the old debtors stay in its database,
-          // also having Meilisearch on while adding debtors triggers the update content hook after
-          // every query, therefore the best solution is to turn the Meilisearch off while adding new debtors
-          // and turn it back on afterward.
-          // See `strapi/patches/strapi-plugin-meilisearch+0.7.1.patch`.
-          await meilisearch.emptyOrDeleteIndex({
-            contentType: 'api::waste-collection-day.waste-collection-day',
-          })
-        }
-
-        await deleteWasteCollectionDays()
 
         try {
-          for (const day of parsedWasteCollectionDays) {
-            // Query Engine API doesn't support relations in bulk options, so Entity Service API is used.
-            // https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/query-engine/bulk-operations.html
-            await strapi.entityService.create('api::waste-collection-day.waste-collection-day', {
-              data: day,
+          const importId = uuid()
+          const parsedWasteCollectionDays = parseWasteCollectionDaysXlsx(file.path, importId)
+
+          try {
+            for (const day of parsedWasteCollectionDays) {
+              // Query Engine API doesn't support relations in bulk options, so Entity Service API is used.
+              // https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/query-engine/bulk-operations.html
+              await strapi.entityService.create('api::waste-collection-day.waste-collection-day', {
+                data: day,
+              })
+            }
+            await meilisearch.updateContentTypeInMeiliSearch({
+              contentType: 'api::waste-collection-day.waste-collection-day',
             })
+          } catch (createWasteCollectionDaysError) {
+            // In case of failure to add some debtor we want to delete all the previously created entries, so we call the
+            // delete function but rethrow the error to be caught by the parent try/catch block.
+            await deleteWasteCollectionDays()
+
+            throw createWasteCollectionDaysError
           }
+
+          ctx.body = {
+            message: `Nahraných ${parsedWasteCollectionDays.length} odvozových dní.`,
+            importId,
+          }
+        } catch (e) {
+          ctx.status = 400
+          ctx.body = {
+            message: e.toString(),
+          }
+        }
+      },
+      async deleteWasteCollectionDays(ctx) {
+        const { type } = ctx.request.params
+
+        try {
+          await deleteWasteCollectionDays(type)
+
+          ctx.body = {
+            message: 'Všetky odvozové dni boli odstránené.',
+          }
+        } catch (e) {
+          ctx.status = 400
+          ctx.body = {
+            message: e.toString(),
+          }
+        }
+      },
+      async updateMeilisearchWasteCollectionDays(ctx) {
+        try {
           await meilisearch.updateContentTypeInMeiliSearch({
             contentType: 'api::waste-collection-day.waste-collection-day',
           })
-        } catch (createWasteCollectionDaysError) {
-          // In case of failure to add some debtor we want to delete all the previously created entries, so we call the
-          // delete function but rethrow the error to be caught by the parent try/catch block.
-          await deleteWasteCollectionDays()
 
-          throw createWasteCollectionDaysError
+          ctx.body = {
+            message:
+              'Aktualizácia odvozových dní prebehla úspešne. Zmeny by sa mali prejaviť na webe okamžite.',
+          }
+        } catch (e) {
+          ctx.status = 400
+          ctx.body = {
+            message: e.toString(),
+          }
         }
-
-        ctx.body = {
-          message: `Nahraných ${parsedWasteCollectionDays.length} odvozových dní.`,
-          importId,
-        }
-      } catch (e) {
-        ctx.status = 400
-        ctx.body = {
-          message: e.toString(),
-        }
-      }
-    },
-  }),
+      },
+    }
+  },
 }

--- a/strapi/src/plugins/waste-collection-days-import/server/routes/index.ts
+++ b/strapi/src/plugins/waste-collection-days-import/server/routes/index.ts
@@ -7,6 +7,16 @@ export default {
         path: '/update-waste-collection-days',
         handler: 'importXlsxController.updateWasteCollectionDays',
       },
+      {
+        method: 'POST',
+        path: '/delete-waste-collection-days/:type',
+        handler: 'importXlsxController.deleteWasteCollectionDays',
+      },
+      {
+        method: 'POST',
+        path: '/update-meilisearch-waste-collection-days',
+        handler: 'importXlsxController.updateMeilisearchWasteCollectionDays',
+      },
     ],
   },
 }


### PR DESCRIPTION
- add option to delete Waste Collection Days by type (entered as string)
- add button to update meilisearch index
  - this is needed when some changes are made maunally in content manager, because automatic updates for this index are turned off due to plugin needs

Note that it is still in MVP state.

![image](https://github.com/user-attachments/assets/0d897479-2867-4462-ae58-f7d638d57f27)
