### PR TITLE
Add field to track page content state #micromanagement

### DIFF
--- a/next/src/services/graphql/api.ts
+++ b/next/src/services/graphql/api.ts
@@ -1767,6 +1767,57 @@ export type ContactRelationResponseCollection = {
   data: Array<ContactEntity>
 }
 
+export type ContentOwner = {
+  __typename?: 'ContentOwner'
+  createdAt?: Maybe<Scalars['DateTime']['output']>
+  email?: Maybe<Scalars['String']['output']>
+  name: Scalars['String']['output']
+  pages?: Maybe<PageRelationResponseCollection>
+  updatedAt?: Maybe<Scalars['DateTime']['output']>
+}
+
+export type ContentOwnerPagesArgs = {
+  filters?: InputMaybe<PageFiltersInput>
+  pagination?: InputMaybe<PaginationArg>
+  publicationState?: InputMaybe<PublicationState>
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
+}
+
+export type ContentOwnerEntity = {
+  __typename?: 'ContentOwnerEntity'
+  attributes?: Maybe<ContentOwner>
+  id?: Maybe<Scalars['ID']['output']>
+}
+
+export type ContentOwnerEntityResponse = {
+  __typename?: 'ContentOwnerEntityResponse'
+  data?: Maybe<ContentOwnerEntity>
+}
+
+export type ContentOwnerEntityResponseCollection = {
+  __typename?: 'ContentOwnerEntityResponseCollection'
+  data: Array<ContentOwnerEntity>
+  meta: ResponseCollectionMeta
+}
+
+export type ContentOwnerFiltersInput = {
+  and?: InputMaybe<Array<InputMaybe<ContentOwnerFiltersInput>>>
+  createdAt?: InputMaybe<DateTimeFilterInput>
+  email?: InputMaybe<StringFilterInput>
+  id?: InputMaybe<IdFilterInput>
+  name?: InputMaybe<StringFilterInput>
+  not?: InputMaybe<ContentOwnerFiltersInput>
+  or?: InputMaybe<Array<InputMaybe<ContentOwnerFiltersInput>>>
+  pages?: InputMaybe<PageFiltersInput>
+  updatedAt?: InputMaybe<DateTimeFilterInput>
+}
+
+export type ContentOwnerInput = {
+  email?: InputMaybe<Scalars['String']['input']>
+  name?: InputMaybe<Scalars['String']['input']>
+  pages?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>
+}
+
 export type DateTimeFilterInput = {
   and?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>
   between?: InputMaybe<Array<InputMaybe<Scalars['DateTime']['input']>>>
@@ -2055,6 +2106,13 @@ export enum Enum_Componentsectionswastecollectionpoints_Backgroundcolor {
 export enum Enum_Componentsharedmetasocial_Socialnetwork {
   Facebook = 'Facebook',
   Twitter = 'Twitter',
+}
+
+export enum Enum_Page_Contentstate {
+  ContentStateDone = 'contentState_done',
+  ContentStateFinalising = 'contentState_finalising',
+  ContentStateInProgress = 'contentState_inProgress',
+  ContentStateTodo = 'contentState_todo',
 }
 
 export enum Enum_Servicecategory_Categorycolor {
@@ -2421,6 +2479,7 @@ export type GenericMorph =
   | ComponentSidebarsContactsSidebar
   | ComponentSidebarsEmptySidebar
   | Contact
+  | ContentOwner
   | Document
   | DocumentCategory
   | Faq
@@ -2638,6 +2697,7 @@ export type Mutation = {
   createBranch?: Maybe<BranchEntityResponse>
   createBranchLocalization?: Maybe<BranchEntityResponse>
   createContact?: Maybe<ContactEntityResponse>
+  createContentOwner?: Maybe<ContentOwnerEntityResponse>
   createDocument?: Maybe<DocumentEntityResponse>
   createDocumentCategory?: Maybe<DocumentCategoryEntityResponse>
   createDocumentCategoryLocalization?: Maybe<DocumentCategoryEntityResponse>
@@ -2671,6 +2731,7 @@ export type Mutation = {
   deleteArticleCategory?: Maybe<ArticleCategoryEntityResponse>
   deleteBranch?: Maybe<BranchEntityResponse>
   deleteContact?: Maybe<ContactEntityResponse>
+  deleteContentOwner?: Maybe<ContentOwnerEntityResponse>
   deleteDocument?: Maybe<DocumentEntityResponse>
   deleteDocumentCategory?: Maybe<DocumentCategoryEntityResponse>
   deleteFaq?: Maybe<FaqEntityResponse>
@@ -2708,6 +2769,7 @@ export type Mutation = {
   updateArticleCategory?: Maybe<ArticleCategoryEntityResponse>
   updateBranch?: Maybe<BranchEntityResponse>
   updateContact?: Maybe<ContactEntityResponse>
+  updateContentOwner?: Maybe<ContentOwnerEntityResponse>
   updateDocument?: Maybe<DocumentEntityResponse>
   updateDocumentCategory?: Maybe<DocumentCategoryEntityResponse>
   updateFaq?: Maybe<FaqEntityResponse>
@@ -2775,6 +2837,10 @@ export type MutationCreateBranchLocalizationArgs = {
 
 export type MutationCreateContactArgs = {
   data: ContactInput
+}
+
+export type MutationCreateContentOwnerArgs = {
+  data: ContentOwnerInput
 }
 
 export type MutationCreateDocumentArgs = {
@@ -2933,6 +2999,10 @@ export type MutationDeleteContactArgs = {
   id: Scalars['ID']['input']
 }
 
+export type MutationDeleteContentOwnerArgs = {
+  id: Scalars['ID']['input']
+}
+
 export type MutationDeleteDocumentArgs = {
   id: Scalars['ID']['input']
 }
@@ -3073,6 +3143,11 @@ export type MutationUpdateBranchArgs = {
 
 export type MutationUpdateContactArgs = {
   data: ContactInput
+  id: Scalars['ID']['input']
+}
+
+export type MutationUpdateContentOwnerArgs = {
+  data: ContentOwnerInput
   id: Scalars['ID']['input']
 }
 
@@ -3350,6 +3425,8 @@ export type PageFiltersInput = {
   and?: InputMaybe<Array<InputMaybe<PageFiltersInput>>>
   branch?: InputMaybe<BranchFiltersInput>
   childPages?: InputMaybe<PageFiltersInput>
+  contentOwner?: InputMaybe<ContentOwnerFiltersInput>
+  contentState?: InputMaybe<StringFilterInput>
   createdAt?: InputMaybe<DateTimeFilterInput>
   id?: InputMaybe<IdFilterInput>
   locale?: InputMaybe<StringFilterInput>
@@ -3379,6 +3456,8 @@ export type PageInput = {
   alias?: InputMaybe<Scalars['String']['input']>
   branch?: InputMaybe<Scalars['ID']['input']>
   childPages?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>
+  contentOwner?: InputMaybe<Scalars['ID']['input']>
+  contentState?: InputMaybe<Enum_Page_Contentstate>
   header?: InputMaybe<Array<Scalars['PageHeaderDynamicZoneInput']['input']>>
   parentPage?: InputMaybe<Scalars['ID']['input']>
   perex?: InputMaybe<Scalars['String']['input']>
@@ -3461,6 +3540,8 @@ export type Query = {
   branches?: Maybe<BranchEntityResponseCollection>
   contact?: Maybe<ContactEntityResponse>
   contacts?: Maybe<ContactEntityResponseCollection>
+  contentOwner?: Maybe<ContentOwnerEntityResponse>
+  contentOwners?: Maybe<ContentOwnerEntityResponseCollection>
   document?: Maybe<DocumentEntityResponse>
   documentCategories?: Maybe<DocumentCategoryEntityResponseCollection>
   documentCategory?: Maybe<DocumentCategoryEntityResponse>
@@ -3549,6 +3630,16 @@ export type QueryContactsArgs = {
   filters?: InputMaybe<ContactFiltersInput>
   pagination?: InputMaybe<PaginationArg>
   publicationState?: InputMaybe<PublicationState>
+  sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
+}
+
+export type QueryContentOwnerArgs = {
+  id?: InputMaybe<Scalars['ID']['input']>
+}
+
+export type QueryContentOwnersArgs = {
+  filters?: InputMaybe<ContentOwnerFiltersInput>
+  pagination?: InputMaybe<PaginationArg>
   sort?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
 }
 

--- a/strapi/config/sync/admin-role.admin-lztq8g5p.json
+++ b/strapi/config/sync/admin-role.admin-lztq8g5p.json
@@ -184,7 +184,8 @@
           "mapIconName",
           "publicTransportInfo",
           "parkingInfo",
-          "barrierFreeInfo"
+          "barrierFreeInfo",
+          "image"
         ],
         "locales": [
           "sk"
@@ -231,7 +232,8 @@
           "mapIconName",
           "publicTransportInfo",
           "parkingInfo",
-          "barrierFreeInfo"
+          "barrierFreeInfo",
+          "image"
         ],
         "locales": [
           "sk"
@@ -256,7 +258,8 @@
           "mapIconName",
           "publicTransportInfo",
           "parkingInfo",
-          "barrierFreeInfo"
+          "barrierFreeInfo",
+          "image"
         ],
         "locales": [
           "sk"
@@ -325,6 +328,52 @@
           "primaryPhone",
           "secondaryPhone",
           "branches"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::content-owner.content-owner",
+      "properties": {
+        "fields": [
+          "name",
+          "email",
+          "pages"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::content-owner.content-owner",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::content-owner.content-owner",
+      "properties": {
+        "fields": [
+          "name",
+          "email",
+          "pages"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::content-owner.content-owner",
+      "properties": {
+        "fields": [
+          "name",
+          "email",
+          "pages"
         ]
       },
       "conditions": []
@@ -1293,54 +1342,7 @@
       "conditions": []
     },
     {
-      "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
-      "subject": "api::navigation.navigation",
-      "properties": {
-        "fields": [
-          "articlesParentPage",
-          "documentsParentPage",
-          "faqCategoriesParentPage",
-          "servicesParentPage",
-          "workshopsParentPage"
-        ],
-        "locales": [
-          "sk"
-        ]
-      },
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.delete",
-      "actionParameters": {},
-      "subject": "api::navigation.navigation",
-      "properties": {
-        "locales": [
-          "sk"
-        ]
-      },
-      "conditions": []
-    },
-    {
       "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
-      "subject": "api::navigation.navigation",
-      "properties": {
-        "fields": [
-          "articlesParentPage",
-          "documentsParentPage",
-          "faqCategoriesParentPage",
-          "servicesParentPage",
-          "workshopsParentPage"
-        ],
-        "locales": [
-          "sk"
-        ]
-      },
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
       "actionParameters": {},
       "subject": "api::navigation.navigation",
       "properties": {
@@ -1433,7 +1435,9 @@
           "seo.metaRobots",
           "seo.structuredData",
           "seo.metaViewport",
-          "seo.canonicalURL"
+          "seo.canonicalURL",
+          "contentOwner",
+          "contentState"
         ],
         "locales": [
           "sk"
@@ -1490,7 +1494,9 @@
           "seo.metaRobots",
           "seo.structuredData",
           "seo.metaViewport",
-          "seo.canonicalURL"
+          "seo.canonicalURL",
+          "contentOwner",
+          "contentState"
         ],
         "locales": [
           "sk"
@@ -1525,7 +1531,9 @@
           "seo.metaRobots",
           "seo.structuredData",
           "seo.metaViewport",
-          "seo.canonicalURL"
+          "seo.canonicalURL",
+          "contentOwner",
+          "contentState"
         ],
         "locales": [
           "sk"
@@ -1909,6 +1917,13 @@
           "dates.datetime"
         ]
       },
+      "conditions": []
+    },
+    {
+      "action": "plugin::i18n.locale.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
       "conditions": []
     },
     {

--- a/strapi/config/sync/admin-role.strapi-super-admin.json
+++ b/strapi/config/sync/admin-role.strapi-super-admin.json
@@ -335,6 +335,52 @@
     {
       "action": "plugin::content-manager.explorer.create",
       "actionParameters": {},
+      "subject": "api::content-owner.content-owner",
+      "properties": {
+        "fields": [
+          "name",
+          "email",
+          "pages"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::content-owner.content-owner",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::content-owner.content-owner",
+      "properties": {
+        "fields": [
+          "name",
+          "email",
+          "pages"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::content-owner.content-owner",
+      "properties": {
+        "fields": [
+          "name",
+          "email",
+          "pages"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
       "subject": "api::document-category.document-category",
       "properties": {
         "fields": [
@@ -1436,7 +1482,9 @@
           "seo.metaRobots",
           "seo.structuredData",
           "seo.metaViewport",
-          "seo.canonicalURL"
+          "seo.canonicalURL",
+          "contentOwner",
+          "contentState"
         ],
         "locales": [
           "sk"
@@ -1493,7 +1541,9 @@
           "seo.metaRobots",
           "seo.structuredData",
           "seo.metaViewport",
-          "seo.canonicalURL"
+          "seo.canonicalURL",
+          "contentOwner",
+          "contentState"
         ],
         "locales": [
           "sk"
@@ -1528,7 +1578,9 @@
           "seo.metaRobots",
           "seo.structuredData",
           "seo.metaViewport",
-          "seo.canonicalURL"
+          "seo.canonicalURL",
+          "contentOwner",
+          "contentState"
         ],
         "locales": [
           "sk"

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##branch.branch.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##branch.branch.json
@@ -122,8 +122,8 @@
       },
       "navigateToLink": {
         "edit": {
-          "label": "navigateToLink",
-          "description": "",
+          "label": "Odkaz na navigáciu",
+          "description": "Napríklad Google Mapy",
           "placeholder": "",
           "visible": true,
           "editable": true
@@ -192,7 +192,7 @@
       },
       "image": {
         "edit": {
-          "label": "image",
+          "label": "Ilustračný obrázok",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -264,12 +264,6 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "title",
-        "openingTimes",
-        "navigateToLink"
-      ],
       "edit": [
         [
           {
@@ -339,6 +333,12 @@
             "size": 6
           }
         ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "openingTimes",
+        "navigateToLink"
       ]
     },
     "uid": "api::branch.branch"

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##content-owner.content-owner.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##content-owner.content-owner.json
@@ -1,0 +1,157 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::api::content-owner.content-owner",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "name",
+      "defaultSortBy": "name",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "name": {
+        "edit": {
+          "label": "Meno",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "name",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "email": {
+        "edit": {
+          "label": "Email",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "email",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "pages": {
+        "edit": {
+          "label": "Stránky",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "title"
+        },
+        "list": {
+          "label": "pages",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "edit": [
+        [
+          {
+            "name": "name",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "email",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "pages",
+            "size": 6
+          }
+        ]
+      ],
+      "list": [
+        "id",
+        "name",
+        "email",
+        "createdAt"
+      ]
+    },
+    "uid": "api::content-owner.content-owner"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##page.page.json
+++ b/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##page.page.json
@@ -176,6 +176,35 @@
           "sortable": false
         }
       },
+      "contentOwner": {
+        "edit": {
+          "label": "Za obsah zodpovedá",
+          "description": "Slúži iba pre internú evidenciu",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "contentOwner",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "contentState": {
+        "edit": {
+          "label": "Stav obsahu",
+          "description": "Slúži iba pre internú evidenciu",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "contentState",
+          "searchable": true,
+          "sortable": true
+        }
+      },
       "createdAt": {
         "edit": {
           "label": "createdAt",
@@ -293,6 +322,16 @@
           {
             "name": "seo",
             "size": 12
+          }
+        ],
+        [
+          {
+            "name": "contentOwner",
+            "size": 6
+          },
+          {
+            "name": "contentState",
+            "size": 6
           }
         ]
       ],

--- a/strapi/schema.graphql
+++ b/strapi/schema.graphql
@@ -2164,6 +2164,50 @@ type ContactRelationResponseCollection {
   data: [ContactEntity!]!
 }
 
+type ContentOwner {
+  createdAt: DateTime
+  email: String
+  name: String!
+  pages(filters: PageFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): PageRelationResponseCollection
+  updatedAt: DateTime
+}
+
+type ContentOwnerEntity {
+  attributes: ContentOwner
+  id: ID
+}
+
+type ContentOwnerEntityResponse {
+  data: ContentOwnerEntity
+}
+
+type ContentOwnerEntityResponseCollection {
+  data: [ContentOwnerEntity!]!
+  meta: ResponseCollectionMeta!
+}
+
+input ContentOwnerFiltersInput {
+  and: [ContentOwnerFiltersInput]
+  createdAt: DateTimeFilterInput
+  email: StringFilterInput
+  id: IDFilterInput
+  name: StringFilterInput
+  not: ContentOwnerFiltersInput
+  or: [ContentOwnerFiltersInput]
+  pages: PageFiltersInput
+  updatedAt: DateTimeFilterInput
+}
+
+input ContentOwnerInput {
+  email: String
+  name: String
+  pages: [ID]
+}
+
+type ContentOwnerRelationResponseCollection {
+  data: [ContentOwnerEntity!]!
+}
+
 """
 A date string, such as 2007-12-03, compliant with the `full-date` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar.
 """
@@ -2459,6 +2503,13 @@ enum ENUM_COMPONENTSHAREDMETASOCIAL_SOCIALNETWORK {
   Twitter
 }
 
+enum ENUM_PAGE_CONTENTSTATE {
+  contentState_done
+  contentState_finalising
+  contentState_inProgress
+  contentState_todo
+}
+
 enum ENUM_SERVICECATEGORY_CATEGORYCOLOR {
   blue
   green
@@ -2713,7 +2764,7 @@ type FormRelationResponseCollection {
   data: [FormEntity!]!
 }
 
-union GenericMorph = Article | ArticleCategory | Branch | ComponentHeaderSectionsBranchMap | ComponentHeaderSectionsCareers | ComponentHeaderSectionsFeaturedNews | ComponentHeaderSectionsGallery | ComponentHeaderSectionsIcon | ComponentHeaderSectionsImage | ComponentHeaderSectionsPickupDay | ComponentHeaderSectionsSideImage | ComponentItemsAnchor | ComponentItemsBoardMembersItem | ComponentItemsCardSliderCard | ComponentItemsCardsListItem | ComponentItemsColumnsItem | ComponentItemsColumnsListItem | ComponentItemsContactsBranch | ComponentItemsContactsContact | ComponentItemsContactsOpeningTime | ComponentItemsFileItem | ComponentItemsFooterColumn | ComponentItemsFormCtaBannerLink | ComponentItemsHeroMainTile | ComponentItemsHeroSmallTile | ComponentItemsHomepageServiceTile | ComponentItemsLink | ComponentItemsLocationCardsItem | ComponentItemsMenuHeader | ComponentItemsOpeningHoursItem | ComponentItemsOpeningTimesItem | ComponentItemsOrderedCardsItem | ComponentItemsSlide | ComponentItemsSortingGuide | ComponentItemsSortingGuideAccordionItem | ComponentItemsSortingGuideAlertMessage | ComponentItemsSortingGuideItem | ComponentItemsWasteSortingCardsItem | ComponentItemsWorkshopDate | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentSectionsArticles | ComponentSectionsArticlesHomepageSection | ComponentSectionsBanner | ComponentSectionsBoardMembers | ComponentSectionsBranches | ComponentSectionsCardSlider | ComponentSectionsCardsList | ComponentSectionsColumns | ComponentSectionsColumnsList | ComponentSectionsContacts | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaq | ComponentSectionsFaqCategories | ComponentSectionsFiles | ComponentSectionsFormCtaBanner | ComponentSectionsGlobalSearch | ComponentSectionsHeroHomepageSection | ComponentSectionsIframeSection | ComponentSectionsImageAndText | ComponentSectionsImageAndTextOverlapped | ComponentSectionsKoloHomepageSection | ComponentSectionsOpeningTimes | ComponentSectionsOrderedCards | ComponentSectionsRichtext | ComponentSectionsServices | ComponentSectionsServicesHomepageSection | ComponentSectionsSortingGuide | ComponentSectionsSortingGuideAccordions | ComponentSectionsVacancies | ComponentSectionsWasteCollectionDays | ComponentSectionsWasteCollectionPoints | ComponentSectionsWasteRemovalCards | ComponentSectionsWasteSortingCards | ComponentSectionsWorkshops | ComponentSharedMetaSocial | ComponentSharedSeo | ComponentSidebarsContactsSidebar | ComponentSidebarsEmptySidebar | Contact | Document | DocumentCategory | Faq | FaqCategory | Footer | Form | Homepage | I18NLocale | Menu | Navigation | OpeningTime | Page | Service | ServiceCategory | Tag | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | WasteCollectionDay | Workshop
+union GenericMorph = Article | ArticleCategory | Branch | ComponentHeaderSectionsBranchMap | ComponentHeaderSectionsCareers | ComponentHeaderSectionsFeaturedNews | ComponentHeaderSectionsGallery | ComponentHeaderSectionsIcon | ComponentHeaderSectionsImage | ComponentHeaderSectionsPickupDay | ComponentHeaderSectionsSideImage | ComponentItemsAnchor | ComponentItemsBoardMembersItem | ComponentItemsCardSliderCard | ComponentItemsCardsListItem | ComponentItemsColumnsItem | ComponentItemsColumnsListItem | ComponentItemsContactsBranch | ComponentItemsContactsContact | ComponentItemsContactsOpeningTime | ComponentItemsFileItem | ComponentItemsFooterColumn | ComponentItemsFormCtaBannerLink | ComponentItemsHeroMainTile | ComponentItemsHeroSmallTile | ComponentItemsHomepageServiceTile | ComponentItemsLink | ComponentItemsLocationCardsItem | ComponentItemsMenuHeader | ComponentItemsOpeningHoursItem | ComponentItemsOpeningTimesItem | ComponentItemsOrderedCardsItem | ComponentItemsSlide | ComponentItemsSortingGuide | ComponentItemsSortingGuideAccordionItem | ComponentItemsSortingGuideAlertMessage | ComponentItemsSortingGuideItem | ComponentItemsWasteSortingCardsItem | ComponentItemsWorkshopDate | ComponentMenuMenuItem | ComponentMenuMenuLink | ComponentMenuMenuSection | ComponentSectionsArticles | ComponentSectionsArticlesHomepageSection | ComponentSectionsBanner | ComponentSectionsBoardMembers | ComponentSectionsBranches | ComponentSectionsCardSlider | ComponentSectionsCardsList | ComponentSectionsColumns | ComponentSectionsColumnsList | ComponentSectionsContacts | ComponentSectionsDivider | ComponentSectionsDocuments | ComponentSectionsFaq | ComponentSectionsFaqCategories | ComponentSectionsFiles | ComponentSectionsFormCtaBanner | ComponentSectionsGlobalSearch | ComponentSectionsHeroHomepageSection | ComponentSectionsIframeSection | ComponentSectionsImageAndText | ComponentSectionsImageAndTextOverlapped | ComponentSectionsKoloHomepageSection | ComponentSectionsOpeningTimes | ComponentSectionsOrderedCards | ComponentSectionsRichtext | ComponentSectionsServices | ComponentSectionsServicesHomepageSection | ComponentSectionsSortingGuide | ComponentSectionsSortingGuideAccordions | ComponentSectionsVacancies | ComponentSectionsWasteCollectionDays | ComponentSectionsWasteCollectionPoints | ComponentSectionsWasteRemovalCards | ComponentSectionsWasteSortingCards | ComponentSectionsWorkshops | ComponentSharedMetaSocial | ComponentSharedSeo | ComponentSidebarsContactsSidebar | ComponentSidebarsEmptySidebar | Contact | ContentOwner | Document | DocumentCategory | Faq | FaqCategory | Footer | Form | Homepage | I18NLocale | Menu | Navigation | OpeningTime | Page | Service | ServiceCategory | Tag | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser | WasteCollectionDay | Workshop
 
 type Homepage {
   articlesSection: ComponentSectionsArticlesHomepageSection
@@ -2973,6 +3024,7 @@ type Mutation {
   createBranch(data: BranchInput!, locale: I18NLocaleCode): BranchEntityResponse
   createBranchLocalization(data: BranchInput, id: ID, locale: I18NLocaleCode): BranchEntityResponse
   createContact(data: ContactInput!): ContactEntityResponse
+  createContentOwner(data: ContentOwnerInput!): ContentOwnerEntityResponse
   createDocument(data: DocumentInput!): DocumentEntityResponse
   createDocumentCategory(data: DocumentCategoryInput!, locale: I18NLocaleCode): DocumentCategoryEntityResponse
   createDocumentCategoryLocalization(data: DocumentCategoryInput, id: ID, locale: I18NLocaleCode): DocumentCategoryEntityResponse
@@ -3008,6 +3060,7 @@ type Mutation {
   deleteArticleCategory(id: ID!, locale: I18NLocaleCode): ArticleCategoryEntityResponse
   deleteBranch(id: ID!, locale: I18NLocaleCode): BranchEntityResponse
   deleteContact(id: ID!): ContactEntityResponse
+  deleteContentOwner(id: ID!): ContentOwnerEntityResponse
   deleteDocument(id: ID!): DocumentEntityResponse
   deleteDocumentCategory(id: ID!, locale: I18NLocaleCode): DocumentCategoryEntityResponse
   deleteFaq(id: ID!, locale: I18NLocaleCode): FaqEntityResponse
@@ -3053,6 +3106,7 @@ type Mutation {
   updateArticleCategory(data: ArticleCategoryInput!, id: ID!, locale: I18NLocaleCode): ArticleCategoryEntityResponse
   updateBranch(data: BranchInput!, id: ID!, locale: I18NLocaleCode): BranchEntityResponse
   updateContact(data: ContactInput!, id: ID!): ContactEntityResponse
+  updateContentOwner(data: ContentOwnerInput!, id: ID!): ContentOwnerEntityResponse
   updateDocument(data: DocumentInput!, id: ID!): DocumentEntityResponse
   updateDocumentCategory(data: DocumentCategoryInput!, id: ID!, locale: I18NLocaleCode): DocumentCategoryEntityResponse
   updateFaq(data: FaqInput!, id: ID!, locale: I18NLocaleCode): FaqEntityResponse
@@ -3215,6 +3269,8 @@ input PageFiltersInput {
   and: [PageFiltersInput]
   branch: BranchFiltersInput
   childPages: PageFiltersInput
+  contentOwner: ContentOwnerFiltersInput
+  contentState: StringFilterInput
   createdAt: DateTimeFilterInput
   id: IDFilterInput
   locale: StringFilterInput
@@ -3238,6 +3294,8 @@ input PageInput {
   alias: String
   branch: ID
   childPages: [ID]
+  contentOwner: ID
+  contentState: ENUM_PAGE_CONTENTSTATE
   header: [PageHeaderDynamicZoneInput!]
   parentPage: ID
   perex: String
@@ -3289,6 +3347,8 @@ type Query {
   branches(filters: BranchFiltersInput, locale: I18NLocaleCode, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): BranchEntityResponseCollection
   contact(id: ID): ContactEntityResponse
   contacts(filters: ContactFiltersInput, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): ContactEntityResponseCollection
+  contentOwner(id: ID): ContentOwnerEntityResponse
+  contentOwners(filters: ContentOwnerFiltersInput, pagination: PaginationArg = {}, sort: [String] = []): ContentOwnerEntityResponseCollection
   document(id: ID): DocumentEntityResponse
   documentCategories(filters: DocumentCategoryFiltersInput, locale: I18NLocaleCode, pagination: PaginationArg = {}, publicationState: PublicationState = LIVE, sort: [String] = []): DocumentCategoryEntityResponseCollection
   documentCategory(id: ID, locale: I18NLocaleCode): DocumentCategoryEntityResponse

--- a/strapi/src/admin/app.tsx
+++ b/strapi/src/admin/app.tsx
@@ -21,6 +21,11 @@ export default {
         'Auth.form.username.placeholder': 'napr. jankohrasko',
         'Auth.form.email.placeholder': 'napr. janko.hrasko@bratislava.sk',
         'Settings.webhooks.trigger.test': 'Testovací beh',
+        // Used in page.contentState field
+        'contentState.todo': 'TODO',
+        'contentState.inProgress': 'IN PROGRESS',
+        'contentState.finalising': 'FINALISING',
+        'contentState.done': 'DONE',
       },
     },
   },

--- a/strapi/src/api/content-owner/content-types/content-owner/schema.json
+++ b/strapi/src/api/content-owner/content-types/content-owner/schema.json
@@ -1,0 +1,29 @@
+{
+  "kind": "collectionType",
+  "collectionName": "content_owners",
+  "info": {
+    "singularName": "content-owner",
+    "pluralName": "content-owners",
+    "displayName": "Zodpovedné osoby",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "email": {
+      "type": "email"
+    },
+    "pages": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::page.page",
+      "mappedBy": "contentOwner"
+    }
+  }
+}

--- a/strapi/src/api/content-owner/controllers/content-owner.ts
+++ b/strapi/src/api/content-owner/controllers/content-owner.ts
@@ -1,0 +1,7 @@
+/**
+ * content-owner controller
+ */
+
+import { factories } from '@strapi/strapi'
+
+export default factories.createCoreController('api::content-owner.content-owner');

--- a/strapi/src/api/content-owner/routes/content-owner.ts
+++ b/strapi/src/api/content-owner/routes/content-owner.ts
@@ -1,0 +1,7 @@
+/**
+ * content-owner router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::content-owner.content-owner');

--- a/strapi/src/api/content-owner/services/content-owner.ts
+++ b/strapi/src/api/content-owner/services/content-owner.ts
@@ -1,0 +1,7 @@
+/**
+ * content-owner service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::content-owner.content-owner');

--- a/strapi/src/api/page/content-types/page/schema.json
+++ b/strapi/src/api/page/content-types/page/schema.json
@@ -121,7 +121,10 @@
         }
       },
       "type": "dynamiczone",
-      "components": ["sidebars.empty-sidebar", "sidebars.contacts-sidebar"],
+      "components": [
+        "sidebars.empty-sidebar",
+        "sidebars.contacts-sidebar"
+      ],
       "max": 1
     },
     "branch": {
@@ -139,6 +142,29 @@
         }
       },
       "component": "shared.seo"
+    },
+    "contentOwner": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::content-owner.content-owner",
+      "private": true,
+      "inversedBy": "pages"
+    },
+    "contentState": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "enumeration",
+      "enum": [
+        "contentState.todo",
+        "contentState.inProgress",
+        "contentState.finalising",
+        "contentState.done"
+      ],
+      "default": "contentState.todo",
+      "private": true
     }
   }
 }

--- a/strapi/types/generated/components.d.ts
+++ b/strapi/types/generated/components.d.ts
@@ -717,6 +717,114 @@ export interface MenuMenuItem extends Schema.Component {
   }
 }
 
+export interface HeaderSectionsSideImage extends Schema.Component {
+  collectionName: 'components_header_sections_side_images'
+  info: {
+    displayName: 'Obr\u00E1zok vpravo'
+    icon: 'picture'
+    description: ''
+  }
+  attributes: {
+    media: Attribute.Media<'images'> & Attribute.Required
+  }
+}
+
+export interface HeaderSectionsPickupDay extends Schema.Component {
+  collectionName: 'components_header_sections_pickup_days'
+  info: {
+    displayName: 'Odvozov\u00FD de\u0148'
+    description: ''
+  }
+  attributes: {
+    anchors: Attribute.Component<'items.anchor', true>
+    carouselTitle: Attribute.String & Attribute.Required
+    tags: Attribute.Relation<'header-sections.pickup-day', 'oneToMany', 'api::tag.tag'>
+    showMoreLink: Attribute.Component<'items.link'>
+  }
+}
+
+export interface HeaderSectionsImage extends Schema.Component {
+  collectionName: 'components_header_sections_images'
+  info: {
+    displayName: 'Obr\u00E1zok na cel\u00FA \u0161\u00EDrku'
+    icon: 'picture'
+    description: ''
+  }
+  attributes: {
+    media: Attribute.Media<'images'> & Attribute.Required
+  }
+}
+
+export interface HeaderSectionsIcon extends Schema.Component {
+  collectionName: 'components_header_sections_icons'
+  info: {
+    displayName: 'Ikonka'
+    description: ''
+  }
+  attributes: {
+    iconName: Attribute.String & Attribute.Required
+  }
+}
+
+export interface HeaderSectionsGallery extends Schema.Component {
+  collectionName: 'components_header_sections_galleries'
+  info: {
+    displayName: 'Gal\u00E9ria'
+    icon: 'landscape'
+    description: ''
+  }
+  attributes: {
+    medias: Attribute.Media<'images', true> & Attribute.Required
+  }
+}
+
+export interface HeaderSectionsFeaturedNews extends Schema.Component {
+  collectionName: 'components_header_sections_featured_news'
+  info: {
+    displayName: 'Aktuality (\u010Dl\u00E1nky)'
+    description: ''
+  }
+  attributes: {
+    articlesTitle: Attribute.String & Attribute.Required
+    firstArticle: Attribute.Relation<
+      'header-sections.featured-news',
+      'oneToOne',
+      'api::article.article'
+    >
+    secondArticle: Attribute.Relation<
+      'header-sections.featured-news',
+      'oneToOne',
+      'api::article.article'
+    >
+  }
+}
+
+export interface HeaderSectionsCareers extends Schema.Component {
+  collectionName: 'components_header_sections_careers'
+  info: {
+    displayName: 'Kari\u00E9ra'
+    description: ''
+  }
+  attributes: {
+    image: Attribute.Media<'images'>
+    imageQuote: Attribute.Text
+    alternativeTextVideo: Attribute.Text
+    videoUrl: Attribute.String & Attribute.Required
+  }
+}
+
+export interface HeaderSectionsBranchMap extends Schema.Component {
+  collectionName: 'components_header_sections_branch_maps'
+  info: {
+    displayName: 'Mapa pobo\u010Diek'
+    icon: 'pinMap'
+    description: ''
+  }
+  attributes: {
+    branches: Attribute.Relation<'header-sections.branch-map', 'oneToMany', 'api::branch.branch'>
+  }
+}
+
 export interface ItemsWorkshopDate extends Schema.Component {
   collectionName: 'components_items_workshop_dates'
   info: {
@@ -1110,114 +1218,6 @@ export interface ItemsAnchor extends Schema.Component {
   }
 }
 
-export interface HeaderSectionsSideImage extends Schema.Component {
-  collectionName: 'components_header_sections_side_images'
-  info: {
-    displayName: 'Obr\u00E1zok vpravo'
-    icon: 'picture'
-    description: ''
-  }
-  attributes: {
-    media: Attribute.Media<'images'> & Attribute.Required
-  }
-}
-
-export interface HeaderSectionsPickupDay extends Schema.Component {
-  collectionName: 'components_header_sections_pickup_days'
-  info: {
-    displayName: 'Odvozov\u00FD de\u0148'
-    description: ''
-  }
-  attributes: {
-    anchors: Attribute.Component<'items.anchor', true>
-    carouselTitle: Attribute.String & Attribute.Required
-    tags: Attribute.Relation<'header-sections.pickup-day', 'oneToMany', 'api::tag.tag'>
-    showMoreLink: Attribute.Component<'items.link'>
-  }
-}
-
-export interface HeaderSectionsImage extends Schema.Component {
-  collectionName: 'components_header_sections_images'
-  info: {
-    displayName: 'Obr\u00E1zok na cel\u00FA \u0161\u00EDrku'
-    icon: 'picture'
-    description: ''
-  }
-  attributes: {
-    media: Attribute.Media<'images'> & Attribute.Required
-  }
-}
-
-export interface HeaderSectionsIcon extends Schema.Component {
-  collectionName: 'components_header_sections_icons'
-  info: {
-    displayName: 'Ikonka'
-    description: ''
-  }
-  attributes: {
-    iconName: Attribute.String & Attribute.Required
-  }
-}
-
-export interface HeaderSectionsGallery extends Schema.Component {
-  collectionName: 'components_header_sections_galleries'
-  info: {
-    displayName: 'Gal\u00E9ria'
-    icon: 'landscape'
-    description: ''
-  }
-  attributes: {
-    medias: Attribute.Media<'images', true> & Attribute.Required
-  }
-}
-
-export interface HeaderSectionsFeaturedNews extends Schema.Component {
-  collectionName: 'components_header_sections_featured_news'
-  info: {
-    displayName: 'Aktuality (\u010Dl\u00E1nky)'
-    description: ''
-  }
-  attributes: {
-    articlesTitle: Attribute.String & Attribute.Required
-    firstArticle: Attribute.Relation<
-      'header-sections.featured-news',
-      'oneToOne',
-      'api::article.article'
-    >
-    secondArticle: Attribute.Relation<
-      'header-sections.featured-news',
-      'oneToOne',
-      'api::article.article'
-    >
-  }
-}
-
-export interface HeaderSectionsCareers extends Schema.Component {
-  collectionName: 'components_header_sections_careers'
-  info: {
-    displayName: 'Kari\u00E9ra'
-    description: ''
-  }
-  attributes: {
-    image: Attribute.Media<'images'>
-    imageQuote: Attribute.Text
-    alternativeTextVideo: Attribute.Text
-    videoUrl: Attribute.String & Attribute.Required
-  }
-}
-
-export interface HeaderSectionsBranchMap extends Schema.Component {
-  collectionName: 'components_header_sections_branch_maps'
-  info: {
-    displayName: 'Mapa pobo\u010Diek'
-    icon: 'pinMap'
-    description: ''
-  }
-  attributes: {
-    branches: Attribute.Relation<'header-sections.branch-map', 'oneToMany', 'api::branch.branch'>
-  }
-}
-
 declare module '@strapi/types' {
   export module Shared {
     export interface Components {
@@ -1263,6 +1263,14 @@ declare module '@strapi/types' {
       'menu.menu-section': MenuMenuSection
       'menu.menu-link': MenuMenuLink
       'menu.menu-item': MenuMenuItem
+      'header-sections.side-image': HeaderSectionsSideImage
+      'header-sections.pickup-day': HeaderSectionsPickupDay
+      'header-sections.image': HeaderSectionsImage
+      'header-sections.icon': HeaderSectionsIcon
+      'header-sections.gallery': HeaderSectionsGallery
+      'header-sections.featured-news': HeaderSectionsFeaturedNews
+      'header-sections.careers': HeaderSectionsCareers
+      'header-sections.branch-map': HeaderSectionsBranchMap
       'items.workshop-date': ItemsWorkshopDate
       'items.waste-sorting-cards-item': ItemsWasteSortingCardsItem
       'items.sorting-guide': ItemsSortingGuide
@@ -1291,14 +1299,6 @@ declare module '@strapi/types' {
       'items.card-slider-card': ItemsCardSliderCard
       'items.board-members-item': ItemsBoardMembersItem
       'items.anchor': ItemsAnchor
-      'header-sections.side-image': HeaderSectionsSideImage
-      'header-sections.pickup-day': HeaderSectionsPickupDay
-      'header-sections.image': HeaderSectionsImage
-      'header-sections.icon': HeaderSectionsIcon
-      'header-sections.gallery': HeaderSectionsGallery
-      'header-sections.featured-news': HeaderSectionsFeaturedNews
-      'header-sections.careers': HeaderSectionsCareers
-      'header-sections.branch-map': HeaderSectionsBranchMap
     }
   }
 }

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -939,6 +939,30 @@ export interface ApiContactContact extends Schema.CollectionType {
   }
 }
 
+export interface ApiContentOwnerContentOwner extends Schema.CollectionType {
+  collectionName: 'content_owners'
+  info: {
+    singularName: 'content-owner'
+    pluralName: 'content-owners'
+    displayName: 'Zodpovedn\u00E9 osoby'
+    description: ''
+  }
+  options: {
+    draftAndPublish: false
+  }
+  attributes: {
+    name: Attribute.String & Attribute.Required
+    email: Attribute.Email
+    pages: Attribute.Relation<'api::content-owner.content-owner', 'oneToMany', 'api::page.page'>
+    createdAt: Attribute.DateTime
+    updatedAt: Attribute.DateTime
+    createdBy: Attribute.Relation<'api::content-owner.content-owner', 'oneToOne', 'admin::user'> &
+      Attribute.Private
+    updatedBy: Attribute.Relation<'api::content-owner.content-owner', 'oneToOne', 'admin::user'> &
+      Attribute.Private
+  }
+}
+
 export interface ApiDocumentDocument extends Schema.CollectionType {
   collectionName: 'documents'
   info: {
@@ -1526,6 +1550,27 @@ export interface ApiPagePage extends Schema.CollectionType {
           localized: true
         }
       }>
+    contentOwner: Attribute.Relation<
+      'api::page.page',
+      'manyToOne',
+      'api::content-owner.content-owner'
+    > &
+      Attribute.Private
+    contentState: Attribute.Enumeration<
+      [
+        'contentState.todo',
+        'contentState.inProgress',
+        'contentState.finalising',
+        'contentState.done',
+      ]
+    > &
+      Attribute.Private &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false
+        }
+      }> &
+      Attribute.DefaultTo<'contentState.todo'>
     createdAt: Attribute.DateTime
     updatedAt: Attribute.DateTime
     publishedAt: Attribute.DateTime
@@ -1806,6 +1851,7 @@ declare module '@strapi/types' {
       'api::article-category.article-category': ApiArticleCategoryArticleCategory
       'api::branch.branch': ApiBranchBranch
       'api::contact.contact': ApiContactContact
+      'api::content-owner.content-owner': ApiContentOwnerContentOwner
       'api::document.document': ApiDocumentDocument
       'api::document-category.document-category': ApiDocumentCategoryDocumentCategory
       'api::faq.faq': ApiFaqFaq


### PR DESCRIPTION
- add `contentOwner` and `contentState` field to Strapi for internal tracking of content creation progress
- update admin roles to see all new fields
- update config-sync files

![image](https://github.com/user-attachments/assets/af81d002-0d27-4d32-8543-91a93d0abaec)
