### PR TITLE
#672 RichText and Sidebar alignment

### DIFF
--- a/next/src/components/sections/RichtextSection.tsx
+++ b/next/src/components/sections/RichtextSection.tsx
@@ -12,7 +12,7 @@ const RichtextSection = ({ section }: Props) => {
   const { content, backgroundColorRichtext } = section
 
   return (
-    <SectionContainer background={backgroundColorRichtext} className="py-12">
+    <SectionContainer background={backgroundColorRichtext} className="py-18">
       <Markdown content={content} />
     </SectionContainer>
   )


### PR DESCRIPTION
- Typically, our sections have `py-18` and so does `SidebarContent`
- `RichtextSection` was using `py-12`, which is why richtext and sidebar weren't aligned
- To quickly fix the issue, `RichtextSection` was given `py-18`

<img width="955" alt="Screenshot 2024-10-19 at 18 01 22" src="https://github.com/user-attachments/assets/9b3a2147-2ad5-4064-b7eb-9020bfd71835">
