### PR TITLE
Use Query Engine API createMany to bulk import waste collection days

### DIFF
--- a/strapi/src/plugins/waste-collection-days-import/admin/src/components/ImportSection.tsx
+++ b/strapi/src/plugins/waste-collection-days-import/admin/src/components/ImportSection.tsx
@@ -78,13 +78,13 @@ const ImportSection = ({ type }: ImportSectionProps) => {
             title="Nahrávanie úspešné"
             action={
               success.data?.importId && (
-                <Link to={importLinks[type](success.data.importId)}>Zobraziť nahrané data</Link>
+                <Link to={importLinks[type](success.data.importId)}>Zobraziť nahrané dáta</Link>
               )
             }
             variant="success"
             onClose={() => setSuccess(null)}
           >
-            {success.data.message}
+            {success.data.message} ({success.data.executionTime}ms)
           </Alert>
         )}
         {error && (

--- a/strapi/src/plugins/waste-collection-days-import/server/controllers/index.ts
+++ b/strapi/src/plugins/waste-collection-days-import/server/controllers/index.ts
@@ -6,26 +6,31 @@ export default {
   importXlsxController: ({ strapi }: { strapi: Strapi }) => {
     const meilisearch = strapi.plugin('meilisearch').service('meilisearch')
 
-    // TODO: Discuss the behaviour of the import.
-    // All the entries are replaced when a new XLSX is uploaded.
-    const deleteWasteCollectionDays = async (type?: string) => {
+    const updateMeilisearchIndex = async () => {
+      await meilisearch.updateContentTypeInMeiliSearch({
+        contentType: 'api::waste-collection-day.waste-collection-day',
+      })
+    }
+
+    const deleteWasteCollectionDaysFn = async (type?: string) => {
       await strapi.db.query('api::waste-collection-day.waste-collection-day').deleteMany({
         where: {
           type: type,
         },
       })
-      // `deleteMany` doesn't trigger Meilisearch hooks, so the old debtors stay in its database,
-      // also having Meilisearch on while adding debtors triggers the update content hook after
-      // every query, therefore the best solution is to turn the Meilisearch off while adding new debtors
+      // TODO this approach may not be needed anymore, as we us createMany instead of creating entries one by one
+      // `deleteMany` doesn't trigger Meilisearch hooks, so the old entries stay in its database,
+      // also having Meilisearch on while adding entries triggers the update content hook after
+      // every query, therefore the best solution is to turn the Meilisearch off while adding new entries
       // and turn it back on afterward.
-      // See `strapi/patches/strapi-plugin-meilisearch+0.7.1.patch`.
-      await meilisearch.emptyOrDeleteIndex({
-        contentType: 'api::waste-collection-day.waste-collection-day',
-      })
+      // See `strapi/patches/strapi-plugin-meilisearch+0.9.2.patch`.
+      await updateMeilisearchIndex()
     }
 
     return {
       async updateWasteCollectionDays(ctx) {
+        const start = Date.now()
+
         ctx.request.socket.setTimeout(300000) // 5 minutes
 
         const file = ctx.request.files?.file
@@ -44,20 +49,27 @@ export default {
           try {
             // Using Query Engine API because it supports bulk insert
             // Docs: https://docs-v4.strapi.io/dev-docs/api/query-engine/bulk-operations
-            await strapi.db.query('api::waste-collection-day.waste-collection-day').createMany({
-              data: parsedWasteCollectionDays,
-            })
+            //
+            // We had to split the data into chunks because of some error with around 9400 items per query
+            // TODO investigate the error and remove the chunking
+            const chunkSize = 5000
+            for (let i = 0; i < parsedWasteCollectionDays.length; i += chunkSize) {
+              const chunk = parsedWasteCollectionDays.slice(i, i + chunkSize)
 
-            await meilisearch.updateContentTypeInMeiliSearch({
-              contentType: 'api::waste-collection-day.waste-collection-day',
-            })
-          } catch (createWasteCollectionDaysError) {
-            throw createWasteCollectionDaysError
+              await strapi.db.query('api::waste-collection-day.waste-collection-day').createMany({
+                data: chunk,
+              })
+            }
+
+            await updateMeilisearchIndex()
+          } catch (createError) {
+            throw createError
           }
 
           ctx.body = {
             message: `Nahraných ${parsedWasteCollectionDays.length} odvozových dní.`,
             importId,
+            executionTime: Date.now() - start,
           }
         } catch (e) {
           ctx.status = 400
@@ -70,10 +82,10 @@ export default {
         const { type } = ctx.request.params
 
         try {
-          await deleteWasteCollectionDays(type)
+          await deleteWasteCollectionDaysFn(type)
 
           ctx.body = {
-            message: 'Všetky odvozové dni boli odstránené.',
+            message: `Odvozové dni "${type}" boli odstránené.`,
           }
         } catch (e) {
           ctx.status = 400
@@ -84,13 +96,10 @@ export default {
       },
       async updateMeilisearchWasteCollectionDays(ctx) {
         try {
-          await meilisearch.updateContentTypeInMeiliSearch({
-            contentType: 'api::waste-collection-day.waste-collection-day',
-          })
+          await updateMeilisearchIndex()
 
           ctx.body = {
-            message:
-              'Aktualizácia odvozových dní prebehla úspešne. Zmeny by sa mali prejaviť na webe okamžite.',
+            message: 'Aktualizácia odvozových dní prebehla úspešne.',
           }
         } catch (e) {
           ctx.status = 400


### PR DESCRIPTION
- change creating Waste Collection Days entries one by one with Entity Service Api to using `createMany` from Query Engine Api
  - previously, Entity Service Api was used because relations are not supported in `createMany` function, but this was usecase from Marianum. We don't have any relations in our case so we can use `createMany`
  - this change also probably solves problem with meilisearch and its update after each entry creation
- using crateMany witch chunks of array, because I was getting some unknown error for tables with more that 9350 entries (9350 worked, 9400 not, i didn't spent much investigating since we have release date soon and chunked approach works)
- update some messages and wording
- show execution time

Tested on dev, this approach is much faster.