### PR TITLE
#531 Fix focus ring behaviour for "Go back" link in menu

### DIFF
--- a/next/src/components/common/NavBar/MobileNavMenu/MobileNavMenuContent.tsx
+++ b/next/src/components/common/NavBar/MobileNavMenu/MobileNavMenuContent.tsx
@@ -1,5 +1,6 @@
 import * as NavigationMenu from '@radix-ui/react-navigation-menu'
 
+import CardBase from '@/src/components/common/Card/CardBase'
 import Icon from '@/src/components/common/Icon/Icon'
 import { getParsedMenus } from '@/src/components/common/NavBar/NavMenu/getParsedMenus'
 import { useNavMenuContext } from '@/src/components/common/NavBar/NavMenu/NavMenuContextProvider'
@@ -29,16 +30,18 @@ const MobileNavMenuContent = ({ menuItem }: MobileNavMenuContentProps) => {
     >
       <ul>
         <li>
-          {/* Our Button (implemented by react-aria-components) is not compatible with radix and causes press events problem on mobile */}
-          {/* TODO: Potentially extract into a separate component */}
-          <button
-            type="button"
-            onClick={() => setMenuValue('')}
-            className="flex w-full items-center justify-center border-b border-border-default p-4"
-          >
-            <Typography variant="p-default-black">{label}</Typography>
-            <Icon name="sipka-dolava" className="absolute left-4" aria-hidden />
-          </button>
+          <CardBase>
+            {/* TODO: Potentially extract into a separate component */}
+            {/* Our Button (implemented by react-aria-components) is not compatible with radix and causes press events problem on mobile */}
+            <button
+              type="button"
+              onClick={() => setMenuValue('')}
+              className="flex w-full items-center justify-center border-b border-border-default p-4"
+            >
+              <Typography variant="p-default-black">{label}</Typography>
+              <Icon name="sipka-dolava" className="absolute left-4" aria-hidden />
+            </button>
+          </CardBase>
         </li>
 
         <ul className="flex size-full flex-col justify-center gap-6 divide-y divide-border-default px-4 py-6">


### PR DESCRIPTION
- Fix focus ring behaviour by wrapping the "Go back" header in `CardBase`

![Screenshot 2024-10-21 at 14 53 06](https://github.com/user-attachments/assets/7b010a38-637f-4a63-b792-eceb143f6ee4)

